### PR TITLE
Optional permission callback

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -366,7 +366,7 @@ a <code>Notification</code> object and can be created by its
 <pre class="idl">[<span title=dom-Notification>Constructor</span>(DOMString <var title>title</var>, optional <span>NotificationOptions</span> <var title>options</var>)]
 interface <dfn>Notification</dfn> : <span data-anolis-spec=dom>EventTarget</span> {
   static readonly attribute <span>NotificationPermission</span> <span title=dom-Notification-permission>permission</span>;
-  static void <span title=dom-Notification-requestPermission>requestPermission</span>(<span>NotificationPermissionCallback</span> <var title>callback</var>);
+  static void <span title=dom-Notification-requestPermission>requestPermission</span>(optional <span>NotificationPermissionCallback</span> <var title>callback</var>);
 
   attribute <span data-anolis-spec=html>EventHandler</span> <span title=handler-onclick>onclick</span>;
   attribute <span data-anolis-spec=html>EventHandler</span> <span title=handler-onshow>onshow</span>;


### PR DESCRIPTION
The callback is redundant in the following use-case:

``` javascript
var userWantsChatNoficiations = false;

// This would be called when the user says
// they want notifications for chat messages
function userRequestsChatNotifications() {
  // The callback is redundant in this case
  Notification.requestPermission(function() {});
  userWantsChatNoficiations = true;
}

// User gets a new message
function onNewChatMessage(user, msg) {
  // Check if the user wants notifications & we have
  // permission to show them.
  if (userWantsChatNoficiations && Notification.permission == 'granted') {
    new Notification("Message from " + user, {
      body: msg,
      tag: 'msg_' + user
    }).show();
  }
}
```
