### PR TITLE
Add Notification.timestamp and NotificationOptions.timestamp

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -7,6 +7,7 @@ Status: LS
 No Editor: true
 Abstract: This standard defines an API to display notifications to the end user, typically outside the top-level browsing context's viewport. It is designed to be compatible with existing notification systems, while remaining platform-independent.
 Logo: https://resources.whatwg.org/logo-notifications.svg
+Boilerplate: omit feedback-header
 !Participate: <a href=https://github.com/whatwg/notifications>GitHub whatwg/notifications</a> (<a href=https://github.com/whatwg/notifications/issues/new>new issue</a>, <a href=https://github.com/whatwg/notifications/issues>open issues</a>)
 !Participate: <a href=https://wiki.whatwg.org/wiki/IRC>IRC: #whatwg on Freenode</a>
 !Commits: <a href="https://github.com/whatwg/notifications/commits">GitHub whatwg/notifications/commits</a>
@@ -53,6 +54,16 @@ representing either a valid BCP 47 language tag or the empty string.
 
 <p>A <a lt="concept notification">notification</a> has an associated
 <dfn>data</dfn>.
+
+<p>A <a lt="concept notification">notification</a> has an associated
+<dfn>timestamp</dfn> which is an unsigned long long representing the time, in
+milliseconds since 00:00:00 UTC on 1 January 1970, of the event for which the
+notification was created.
+
+<p class=note>Timestamps can be used to indicate the time at which a notification
+is actual. For example, this could be in the past when a notification is used for
+a message that couldn't immediately be delivered because the device was offline,
+or in the future for a meeting that is about to start.
 
 <p>A <a lt="concept notification">notification</a> has an associated
 <dfn lt="concept origin">origin</dfn>.
@@ -156,6 +167,12 @@ or vibration pattern that is not otherwise accessible to the end user.
   <a>validate and normalize</a> it and set <var>notification</var>'s
   <a>vibration pattern</a> to the return value. (Otherwise
   <a>vibration pattern</a> is not set.)
+
+  <li><p>If <var>options</var>'s <code>timestamp</code> is present, set
+  <var>notification</var>'s <a>timestamp</a> to the value. Otherwise, set
+  <var>notification</var>'s <a>timestamp</a> to the number of milliseconds that
+  passed between 00:00:00 UTC on 1 January 1970 and the time at which the
+  <code>Notification</code> constructor was called.
 
   <li><p>If <var>options</var>'s <code>renotify</code> is true, set
   <var>notification</var>'s <a>renotify preference flag</a>.
@@ -447,6 +464,7 @@ interface Notification : EventTarget {
   readonly attribute USVString icon;
   readonly attribute USVString sound;
   readonly attribute FrozenArray&lt;unsigned long> vibrate;
+  readonly attribute unsigned long long timestamp;
   readonly attribute boolean renotify;
   readonly attribute boolean silent;
   readonly attribute boolean noscreen;
@@ -465,6 +483,7 @@ dictionary NotificationOptions {
   USVString icon;
   USVString sound;
   VibratePattern vibrate;
+  unsigned long long timestamp;
   boolean renotify = false;
   boolean silent = false;
   boolean noscreen = false;
@@ -654,6 +673,10 @@ otherwise.
 must return the
 <a lt="concept notification">notification</a>'s <a>vibration pattern</a>, if any, and the
 empty list otherwise.
+
+<p>The <dfn attribute dfn-for=Notification><code>timestamp</code></dfn> attribute's
+getter must return the <a lt="concept notification">notification</a>'s
+<a>timestamp</a>.
 
 <p>The <dfn attribute dfn-for=Notification><code>renotify</code></dfn>
 attribute's getter must return the

--- a/notifications.html
+++ b/notifications.html
@@ -9,9 +9,9 @@
  </head>
  <body class="h-entry status-LS">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-notifications.svg"> </a></p>
+   <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-notifications.svg"> </a> </p>
    <h1 class="p-name no-ref" id="title">Notifications API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-09-02">2 September 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-10-14">14 October 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Participate:
@@ -79,11 +79,11 @@
    </ul>
   </div>
   <main>
-   <script async="" src="https://resources.whatwg.org/file-issue.js"></script>
-   <script defer="" id="head" src="https://resources.whatwg.org/dfn.js"></script>
+<script async="" src="https://resources.whatwg.org/file-issue.js"></script>
+<script defer="" id="head" src="https://resources.whatwg.org/dfn.js"></script>
    <h2 class="heading settled" data-level="1" id="terminology"><span class="secno">1. </span><span class="content">Terminology</span><a class="self-link" href="#terminology"></a></h2>
    <p>Some terms used in this specification are defined in the DOM, Fetch,
-HTML, IDL, URL and Vibration API Standards. <a data-link-type="biblio" href="#biblio-dom">[DOM]</a><a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a><a data-link-type="biblio" href="#biblio-html">[HTML]</a><a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a><a data-link-type="biblio" href="#biblio-url">[URL]</a><a data-link-type="biblio" href="#biblio-vibration">[VIBRATION]</a></p>
+HTML, IDL, URL and Vibration API Standards. <a data-link-type="biblio" href="#biblio-dom">[DOM]</a> <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a> <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a> <a data-link-type="biblio" href="#biblio-url">[URL]</a> <a data-link-type="biblio" href="#biblio-vibration">[VIBRATION]</a> </p>
    <h2 class="heading settled" data-level="2" id="notifications"><span class="secno">2. </span><span class="content">Notifications</span><a class="self-link" href="#notifications"></a></h2>
    <p>A <dfn data-dfn-type="dfn" data-lt="concept notification" data-noexport="" id="concept-notification">notification<a class="self-link" href="#concept-notification"></a></dfn> is an abstract
 representation of something that happened, such as the delivery of a message. </p>
@@ -94,6 +94,13 @@ representation of something that happened, such as the delivery of a message. </
 representing either a valid BCP 47 language tag or the empty string. </p>
    <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="tag">tag<a class="self-link" href="#tag"></a></dfn> which is a DOMString. </p>
    <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="data">data<a class="self-link" href="#data"></a></dfn>. </p>
+   <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="timestamp">timestamp<a class="self-link" href="#timestamp"></a></dfn> which is an unsigned long long representing the time in
+milliseconds since 00:00:00 UTC on 1 January 1970 of the event for which the
+notification was created. </p>
+   <p class="note" role="note">Timestamps can be used to indicate the time at which a notification
+is actual. For example, this could be in the past when a notification is used for
+a message that couldn’t immediately be delivered because the device was offline,
+or in the future for a meeting that is about to start. </p>
    <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> has an associated <dfn data-dfn-type="dfn" data-lt="concept origin" data-noexport="" id="concept-origin">origin<a class="self-link" href="#concept-origin"></a></dfn>. </p>
    <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="renotify-preference-flag">renotify preference flag<a class="self-link" href="#renotify-preference-flag"></a></dfn> which is initially unset. When set indicates
 that the end user should be alerted after the <a data-link-type="dfn" href="#replace-steps">replace steps</a> have run. </p>
@@ -106,13 +113,13 @@ set, indicates that on devices with a sufficiently large screen, the
 notification should remain readily available until the user activates or
 dismisses the notification. </p>
    <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="sticky-preference-flag">sticky preference flag<a class="self-link" href="#sticky-preference-flag"></a></dfn> which is initially unset. When set indicates
-that the end user should not be able to easily clear the <a data-link-type="dfn" href="#concept-notification">notification</a><span class="note" role="note">Only makes sense
+that the end user should not be able to easily clear the <a data-link-type="dfn" href="#concept-notification">notification</a> <span class="note" role="note">Only makes sense
 for <a data-link-type="dfn" href="#persistent-notification">persistent notifications</a>. </span></p>
-   <p>A <a data-link-type="dfn" href="#concept-notification">notification</a><em>can</em> have an
+   <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> <em>can</em> have an
 associated <dfn data-dfn-type="dfn" data-noexport="" id="icon-url">icon URL<a class="self-link" href="#icon-url"></a></dfn>, <dfn data-dfn-type="dfn" data-noexport="" id="icon-resource">icon resource<a class="self-link" href="#icon-resource"></a></dfn>, <dfn data-dfn-type="dfn" data-noexport="" id="sound-url">sound URL<a class="self-link" href="#sound-url"></a></dfn>, <dfn data-dfn-type="dfn" data-noexport="" id="sound-resource">sound resource<a class="self-link" href="#sound-resource"></a></dfn>, <dfn data-dfn-type="dfn" data-noexport="" id="vibration-pattern">vibration pattern<a class="self-link" href="#vibration-pattern"></a></dfn>, and <dfn data-dfn-type="dfn" data-noexport="" id="service-worker-registration">service worker registration<a class="self-link" href="#service-worker-registration"></a></dfn>. </p>
    <p class="note" role="note">Developers are encouraged to not convey information through an icon, sound,
 or vibration pattern that is not otherwise accessible to the end user. </p>
-   <p>A <dfn data-dfn-type="dfn" data-noexport="" id="non_persistent-notification">non-persistent notification<a class="self-link" href="#non_persistent-notification"></a></dfn> is a <a data-link-type="dfn" href="#concept-notification">notification</a> without an associated <a data-link-type="dfn" href="#service-worker-registration">service worker registration</a>. </p>
+   <p>A <dfn data-dfn-type="dfn" data-noexport="" id="non-persistent-notification">non-persistent notification<a class="self-link" href="#non-persistent-notification"></a></dfn> is a <a data-link-type="dfn" href="#concept-notification">notification</a> without an associated <a data-link-type="dfn" href="#service-worker-registration">service worker registration</a>. </p>
    <p>A <dfn data-dfn-type="dfn" data-noexport="" id="persistent-notification">persistent notification<a class="self-link" href="#persistent-notification"></a></dfn> is a <a data-link-type="dfn" href="#concept-notification">notification</a> with an associated <a data-link-type="dfn" href="#service-worker-registration">service worker registration</a>. </p>
    <hr>
    <p>To <dfn data-dfn-type="dfn" data-noexport="" id="create-a-notification">create a notification<a class="self-link" href="#create-a-notification"></a></dfn>, given a <var>title</var> and <var>options, run these steps: </var></p>
@@ -138,7 +145,7 @@ or vibration pattern that is not otherwise accessible to the end user. </p>
     <li>
      <p>Set <var>notification</var>’s <a data-link-type="dfn" href="#tag">tag</a> to <var>options</var>’s <code>tag</code>. </p>
     <li>
-     <p>Let <var>baseURL</var> be the API base URL specified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">entry settings object</a>. <span class="XXX">Or incumbent?</span></p>
+     <p>Let <var>baseURL</var> be the API base URL specified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">entry settings object</a>. <span class="XXX">Or incumbent?</span> </p>
     <li>
      <p>If <var>options</var>’s <code>icon</code> is present, <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser">parse</a> it using <var>baseURL</var>, and if that does not
   return failure, set <var>notification</var>’s <a data-link-type="dfn" href="#icon-url">icon URL</a> to the return
@@ -149,6 +156,9 @@ or vibration pattern that is not otherwise accessible to the end user. </p>
   value. (Otherwise <a data-link-type="dfn" href="#sound-url">sound URL</a> is not set.) </p>
     <li>
      <p>If <var>options</var>’s <code>vibrate</code> is present, <a data-link-type="dfn" href="http://www.w3.org/TR/vibration/#dfn-validate-and-normalize">validate and normalize</a> it and set <var>notification</var>’s <a data-link-type="dfn" href="#vibration-pattern">vibration pattern</a> to the return value. (Otherwise <a data-link-type="dfn" href="#vibration-pattern">vibration pattern</a> is not set.) </p>
+    <li>
+     <p>If <var>options</var>’s <code>timestamp</code> is present, set <var>notification</var>’s <a data-link-type="dfn" href="#timestamp">timestamp</a> to the value. Otherwise, set <var>notification</var>’s <a data-link-type="dfn" href="#timestamp">timestamp</a> to the number of milliseconds that
+  passed between 00:00:00 UTC on 1 January 1970 and the time at which the <code>Notification</code> constructor was called. </p>
     <li>
      <p>If <var>options</var>’s <code>renotify</code> is true, set <var>notification</var>’s <a data-link-type="dfn" href="#renotify-preference-flag">renotify preference flag</a>. </p>
     <li>
@@ -165,9 +175,9 @@ or vibration pattern that is not otherwise accessible to the end user. </p>
    <h3 class="heading settled" data-level="2.1" id="lifetime-and-ui-integrations"><span class="secno">2.1. </span><span class="content">Lifetime and UI integration</span><a class="self-link" href="#lifetime-and-ui-integrations"></a></h3>
    <p>The user agent must keep a <dfn data-dfn-type="dfn" data-noexport="" id="list-of-notifications">list of notifications<a class="self-link" href="#list-of-notifications"></a></dfn> that consists of
 zero or more <a data-link-type="dfn" href="#concept-notification">notifications</a>. </p>
-   <p>User agents should run the <a data-link-type="dfn" href="#close-steps">close steps</a> for a <a data-link-type="dfn" href="#non_persistent-notification">non-persistent notification</a> a couple of seconds after they have been
+   <p>User agents should run the <a data-link-type="dfn" href="#close-steps">close steps</a> for a <a data-link-type="dfn" href="#non-persistent-notification">non-persistent notification</a> a couple of seconds after they have been
 created. </p>
-   <p>User agents should not display <a data-link-type="dfn" href="#non_persistent-notification">non-persistent notification</a> in a
+   <p>User agents should not display <a data-link-type="dfn" href="#non-persistent-notification">non-persistent notification</a> in a
 platform’s "notification center" (if available). </p>
    <p>User agents should persist <a data-link-type="dfn" href="#persistent-notification">persistent notifications</a> until they are
 removed from the <a data-link-type="dfn" href="#list-of-notifications">list of notifications</a>. </p>
@@ -197,23 +207,23 @@ meaning "<code>granted</code>". In that case
 for the application to ask for <a data-link-type="dfn" href="#permission">permission</a>. </p>
    <h3 class="heading settled" data-level="2.3" id="direction"><span class="secno">2.3. </span><span class="content">Direction</span><a class="self-link" href="#direction"></a></h3>
    <p>This section is written in terms equivalent to those used in the Rendering
-section of HTML. <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
+section of HTML. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> </p>
    <p>User agents are expected to honor the Unicode semantics of the text of a <a data-link-type="dfn" href="#concept-notification">notification</a>’s <a data-link-type="dfn" href="#concept-title">title</a> and <a data-link-type="dfn" href="#body">body</a>. Each is expected to be
 treated as an independent set of one or more bidirectional algorithm paragraphs
 when displayed, as defined by the bidirectional algorithm’s rules P1, P2, and
 P3, including, for instance, supporting the paragraph-breaking behavior of
 U+000A LINE FEED (LF) characters. For each paragraph of the <a data-link-type="dfn" href="#concept-title">title</a> and <a data-link-type="dfn" href="#body">body</a>, the <a data-link-type="dfn" href="#concept-notification">notification</a>’s <a data-link-type="dfn" href="#concept-direction">direction</a> provides the higher-level override
-of rules P2 and P3 if it has a value other than "<code>auto</code>". <a data-link-type="biblio" href="#biblio-bidi">[BIDI]</a></p>
+of rules P2 and P3 if it has a value other than "<code>auto</code>". <a data-link-type="biblio" href="#biblio-bidi">[BIDI]</a> </p>
    <h3 class="heading settled" data-level="2.4" id="language"><span class="secno">2.4. </span><span class="content">Language</span><a class="self-link" href="#language"></a></h3>
    <p>The <a data-link-type="dfn" href="#concept-notification">notification</a>’s <a data-link-type="dfn" href="#concept-language">language</a> specifies the primary language for the <a data-link-type="dfn" href="#concept-notification">notification</a>’s <a data-link-type="dfn" href="#concept-title">title</a> and <a data-link-type="dfn" href="#body">body</a>. Its value is a string. The empty string
 indicates that the primary language is unknown. Any other string must be interpreted as a
-language tag. Validity or well-formedness are not enforced. <a data-link-type="biblio" href="#biblio-lang">[LANG]</a></p>
+language tag. Validity or well-formedness are not enforced. <a data-link-type="biblio" href="#biblio-lang">[LANG]</a> </p>
    <p class="note" role="note">Developers are encouraged to only use valid language tags. </p>
    <h3 class="heading settled" data-level="2.5" id="resources"><span class="secno">2.5. </span><span class="content">Resources</span><a class="self-link" href="#resources"></a></h3>
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="fetch-steps">fetch steps<a class="self-link" href="#fetch-steps"></a></dfn> for a given <a data-link-type="dfn" href="#concept-notification">notification</a><var>notification</var> are: </p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="fetch-steps">fetch steps<a class="self-link" href="#fetch-steps"></a></dfn> for a given <a data-link-type="dfn" href="#concept-notification">notification</a> <var>notification</var> are: </p>
    <ol>
     <li>
-     <p>If the notification platform supports icons, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a><var>notification</var>’s <a data-link-type="dfn" href="#icon-url">icon URL</a>, if <a data-link-type="dfn" href="#icon-url">icon URL</a> is set. </p>
+     <p>If the notification platform supports icons, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> <var>notification</var>’s <a data-link-type="dfn" href="#icon-url">icon URL</a>, if <a data-link-type="dfn" href="#icon-url">icon URL</a> is set. </p>
      <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: </p>
      <ol>
       <li>
@@ -225,7 +235,7 @@ language tag. Validity or well-formedness are not enforced. <a data-link-type="b
        <p>If the image format is supported, set <var>notification</var>’s <a data-link-type="dfn" href="#icon-resource">icon resource</a> to the decoded resource. (Otherwise <var>notification</var> has no <a data-link-type="dfn" href="#icon-resource">icon resource</a>.) </p>
      </ol>
     <li>
-     <p>If the notification platform supports sounds, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a><var>notification</var>’s <a data-link-type="dfn" href="#sound-url">sound URL</a>, if <a data-link-type="dfn" href="#sound-url">sound URL</a> is set. </p>
+     <p>If the notification platform supports sounds, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> <var>notification</var>’s <a data-link-type="dfn" href="#sound-url">sound URL</a>, if <a data-link-type="dfn" href="#sound-url">sound URL</a> is set. </p>
      <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: </p>
      <ol>
       <li>
@@ -238,7 +248,7 @@ language tag. Validity or well-formedness are not enforced. <a data-link-type="b
      </ol>
    </ol>
    <h3 class="heading settled" data-level="2.6" id="showing-a-notification"><span class="secno">2.6. </span><span class="content">Showing a notification</span><a class="self-link" href="#showing-a-notification"></a></h3>
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="show-steps">show steps<a class="self-link" href="#show-steps"></a></dfn> for a given <a data-link-type="dfn" href="#concept-notification">notification</a><var>notification</var> are: </p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="show-steps">show steps<a class="self-link" href="#show-steps"></a></dfn> for a given <a data-link-type="dfn" href="#concept-notification">notification</a> <var>notification</var> are: </p>
    <ol>
     <li>
      <p>If there is a <a data-link-type="dfn" href="#concept-notification">notification</a> in the <a data-link-type="dfn" href="#list-of-notifications">list of notifications</a> whose <a data-link-type="dfn" href="#tag">tag</a> is not the empty string and
@@ -247,7 +257,7 @@ language tag. Validity or well-formedness are not enforced. <a data-link-type="b
      <p>Otherwise, run the <a data-link-type="dfn" href="#display-steps">display steps</a> for <var>notification</var>. </p>
    </ol>
    <h3 class="heading settled" data-level="2.7" id="activating-a-notification"><span class="secno">2.7. </span><span class="content">Activating a notification</span><a class="self-link" href="#activating-a-notification"></a></h3>
-   <p>When a <a data-link-type="dfn" href="#concept-notification">notification</a><var>notification</var> is activated by the user, assuming the underlying notification platform supports
+   <p>When a <a data-link-type="dfn" href="#concept-notification">notification</a> <var>notification</var> is activated by the user, assuming the underlying notification platform supports
 activation, the user agent must (unless otherwise specified) run these steps: </p>
    <ol>
     <li>
@@ -300,7 +310,7 @@ must be run. </p>
      <p>Append <var>notification</var> to the <a data-link-type="dfn" href="#list-of-notifications">list of notifications</a>. </p>
    </ol>
    <h3 class="heading settled" data-level="2.10" id="replacing-a-notification"><span class="secno">2.10. </span><span class="content">Replacing a notification</span><a class="self-link" href="#replacing-a-notification"></a></h3>
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="replace-steps">replace steps<a class="self-link" href="#replace-steps"></a></dfn> for replacing an <var>old</var><a data-link-type="dfn" href="#concept-notification">notification</a> with a <var>new</var> one are: </p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="replace-steps">replace steps<a class="self-link" href="#replace-steps"></a></dfn> for replacing an <var>old</var> <a data-link-type="dfn" href="#concept-notification">notification</a> with a <var>new</var> one are: </p>
    <ol>
     <li>
      <p>Wait for any <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetches</a> to complete and <var>notification</var>’s <a data-link-type="dfn" href="#icon-resource">icon resource</a> and <a data-link-type="dfn" href="#sound-resource">sound resource</a> to be set (if any). </p>
@@ -330,6 +340,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="not
   readonly attribute USVString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="USVString " href="#dom-notification-icon">icon</a>;
   readonly attribute USVString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="USVString " href="#dom-notification-sound">sound</a>;
   readonly attribute FrozenArray&lt;unsigned long> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<unsigned long> " href="#dom-notification-vibrate">vibrate</a>;
+  readonly attribute unsigned long long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long " href="#dom-notification-timestamp">timestamp</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-renotify">renotify</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-silent">silent</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-noscreen">noscreen</a>;
@@ -348,6 +359,7 @@ dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="d
   USVString <dfn class="idl-code" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-notificationoptions-icon">icon<a class="self-link" href="#dom-notificationoptions-icon"></a></dfn>;
   USVString <dfn class="idl-code" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-notificationoptions-sound">sound<a class="self-link" href="#dom-notificationoptions-sound"></a></dfn>;
   <a data-link-type="idl-name" href="http://www.w3.org/TR/vibration/#idl-def-VibratePattern">VibratePattern</a> <dfn class="idl-code" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="VibratePattern " id="dom-notificationoptions-vibrate">vibrate<a class="self-link" href="#dom-notificationoptions-vibrate"></a></dfn>;
+  unsigned long long <dfn class="idl-code" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="unsigned long long " id="dom-notificationoptions-timestamp">timestamp<a class="self-link" href="#dom-notificationoptions-timestamp"></a></dfn>;
   boolean <dfn class="idl-code" data-default="false" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-notificationoptions-renotify">renotify<a class="self-link" href="#dom-notificationoptions-renotify"></a></dfn> = false;
   boolean <dfn class="idl-code" data-default="false" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-notificationoptions-silent">silent<a class="self-link" href="#dom-notificationoptions-silent"></a></dfn> = false;
   boolean <dfn class="idl-code" data-default="false" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-notificationoptions-noscreen">noscreen<a class="self-link" href="#dom-notificationoptions-noscreen"></a></dfn> = false;
@@ -370,7 +382,7 @@ enum <dfn class="idl-code" data-dfn-type="enum" data-export="" id="enumdef-notif
 
 callback <dfn class="idl-code" data-dfn-type="callback" data-export="" id="callbackdef-notificationpermissioncallback">NotificationPermissionCallback<a class="self-link" href="#callbackdef-notificationpermissioncallback"></a></dfn> = void (<a data-link-type="idl-name" href="#enumdef-notificationpermission">NotificationPermission</a> <dfn class="idl-code" data-dfn-for="NotificationPermissionCallback" data-dfn-type="argument" data-export="" id="dom-notificationpermissioncallback-permission">permission<a class="self-link" href="#dom-notificationpermissioncallback-permission"></a></dfn>);
 </pre>
-   <p>A <a data-link-type="dfn" href="#non_persistent-notification">non-persistent notification</a> is represented one <code class="idl"><a data-link-type="idl" href="#notification">Notification</a></code> objects and can be created through <code class="idl"><a data-link-type="idl" href="#notification">Notification</a></code>'s <a class="idl-code" data-link-type="constructor" href="#dom-notification-notification">constructor</a>. </p>
+   <p>A <a data-link-type="dfn" href="#non-persistent-notification">non-persistent notification</a> is represented one <code class="idl"><a data-link-type="idl" href="#notification">Notification</a></code> objects and can be created through <code class="idl"><a data-link-type="idl" href="#notification">Notification</a></code>'s <a class="idl-code" data-link-type="constructor" href="#dom-notification-notification">constructor</a>. </p>
    <p>A <a data-link-type="dfn" href="#persistent-notification">persistent notification</a> is represented by zero or more <code class="idl"><a data-link-type="idl" href="#notification">Notification</a></code> objects can be created through the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-shownotification">showNotification()</a></code> method. </p>
    <h3 class="heading settled" data-level="3.1" id="garbage-collection"><span class="secno">3.1. </span><span class="content">Garbage collection</span><a class="self-link" href="#garbage-collection"></a></h3>
    <p>A <code class="idl"><a data-link-type="idl" href="#notification">Notification</a></code> object must not be garbage collected while its
@@ -441,15 +453,15 @@ APIs should not use this pattern and instead employ one of the <a href="http://r
    <table>
     <thead>
      <tr>
-      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a>
-      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-types">event handler event type</a>
+      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> 
+      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-types">event handler event type</a> 
     <tbody>
      <tr>
-      <td><dfn class="idl-code" data-dfn-for="Notification" data-dfn-type="attribute" data-export="" id="dom-notification-onclick"><code>onclick</code><a class="self-link" href="#dom-notification-onclick"></a></dfn>
-      <td><code>click</code>
+      <td><dfn class="idl-code" data-dfn-for="Notification" data-dfn-type="attribute" data-export="" id="dom-notification-onclick"><code>onclick</code><a class="self-link" href="#dom-notification-onclick"></a></dfn> 
+      <td><code>click</code> 
      <tr>
-      <td><dfn class="idl-code" data-dfn-for="Notification" data-dfn-type="attribute" data-export="" id="dom-notification-onerror"><code>onerror</code><a class="self-link" href="#dom-notification-onerror"></a></dfn>
-      <td><code>error</code>
+      <td><dfn class="idl-code" data-dfn-for="Notification" data-dfn-type="attribute" data-export="" id="dom-notification-onerror"><code>onerror</code><a class="self-link" href="#dom-notification-onerror"></a></dfn> 
+      <td><code>error</code> 
    </table>
    <p>The <dfn class="idl-code" data-dfn-for="Notification" data-dfn-type="method" data-export="" id="dom-notification-close"><code>close()</code><a class="self-link" href="#dom-notification-close"></a></dfn> method, when
 invoked, must run the <a data-link-type="dfn" href="#close-steps">close steps</a> for the <a data-link-type="dfn" href="#concept-notification">notification</a>. </p>
@@ -472,6 +484,8 @@ there is no <a data-link-type="dfn" href="#concept-notification">notification</a
    <p>The <dfn class="idl-code" data-dfn-for="Notification" data-dfn-type="attribute" data-export="" id="dom-notification-vibrate"><code>vibrate</code><a class="self-link" href="#dom-notification-vibrate"></a></dfn> attribute’s getter
 must return the <a data-link-type="dfn" href="#concept-notification">notification</a>’s <a data-link-type="dfn" href="#vibration-pattern">vibration pattern</a>, if any, and the
 empty list otherwise. </p>
+   <p>The <dfn class="idl-code" data-dfn-for="Notification" data-dfn-type="attribute" data-export="" id="dom-notification-timestamp"><code>timestamp</code><a class="self-link" href="#dom-notification-timestamp"></a></dfn> attribute’s
+getter must return the <a data-link-type="dfn" href="#concept-notification">notification</a>’s <a data-link-type="dfn" href="#timestamp">timestamp</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Notification" data-dfn-type="attribute" data-export="" id="dom-notification-renotify"><code>renotify</code><a class="self-link" href="#dom-notification-renotify"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#concept-notification">notification</a>’s <a data-link-type="dfn" href="#renotify-preference-flag">renotify preference flag</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Notification" data-dfn-type="attribute" data-export="" id="dom-notification-silent"><code>silent</code><a class="self-link" href="#dom-notification-silent"></a></dfn> attribute’s
 getter must return the <a data-link-type="dfn" href="#concept-notification">notification</a>’s <a data-link-type="dfn" href="#silent-preference-flag">silent preference flag</a>. </p>
@@ -605,11 +619,11 @@ value it was initialized to. </p>
    <table>
     <thead>
      <tr>
-      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a>
-      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-types">event handler event type</a>
+      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> 
+      <th><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-types">event handler event type</a> 
     <tbody>
      <tr>
-      <td><dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-lt="onnotificationclick" id="dom-serviceworkerglobalscope-onnotificationclick"><code> onnotificationclick</code><a class="self-link" href="#dom-serviceworkerglobalscope-onnotificationclick"></a></dfn>
+      <td><dfn class="idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" data-lt="onnotificationclick" id="dom-serviceworkerglobalscope-onnotificationclick"><code> onnotificationclick</code><a class="self-link" href="#dom-serviceworkerglobalscope-onnotificationclick"></a></dfn> 
       <td><code>notificationclick </code>
    </table>
    <h2 class="no-num heading settled" id="acknowledgments"><span class="content">Acknowledgments</span><a class="self-link" href="#acknowledgments"></a></h2>
@@ -651,7 +665,7 @@ neighboring rights to this work. </p>
   <div data-fill-with="conformance">
    <h2 class="no-num no-ref heading settled" id="conformance"><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
    <p>All diagrams, examples, and notes in this specification are non-normative, as are all sections explicitly marked non-normative. Everything else in this specification is normative. </p>
-   <p>The key words "MUST", "MUST NOT", "REQUIRED",  "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this specification are to be interpreted as described in RFC2119. For readability, these words do not appear in all uppercase letters in this specification. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
+   <p>The key words "MUST", "MUST NOT", "REQUIRED",  "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this specification are to be interpreted as described in RFC2119. For readability, these words do not appear in all uppercase letters in this specification. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
    <p>Conformance requirements phrased as algorithms or specific steps may be implemented in any manner, so long as the end result is equivalent. (In particular, the algorithms defined in this specification are intended to be easy to follow, and not intended to be performant.) </p>
   </div>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
@@ -709,7 +723,7 @@ neighboring rights to this work. </p>
      <li><a href="#dom-notification-lang">attribute for Notification</a><span>, in §3.4</span>
     </ul>
    <li><a href="#list-of-notifications">list of notifications</a><span>, in §2.1</span>
-   <li><a href="#non_persistent-notification">non-persistent notification</a><span>, in §2</span>
+   <li><a href="#non-persistent-notification">non-persistent notification</a><span>, in §2</span>
    <li>
     noscreen
     <ul>
@@ -801,6 +815,13 @@ neighboring rights to this work. </p>
      <li><a href="#dom-getnotificationoptions-tag">dict-member for GetNotificationOptions</a><span>, in §4</span>
     </ul>
    <li>
+    timestamp
+    <ul>
+     <li><a href="#timestamp">definition of</a><span>, in §2</span>
+     <li><a href="#dom-notificationoptions-timestamp">dict-member for NotificationOptions</a><span>, in §3</span>
+     <li><a href="#dom-notification-timestamp">attribute for Notification</a><span>, in §3.4</span>
+    </ul>
+   <li>
     title
     <ul>
      <li><a href="#dom-notification-notification-title-options-title">argument for Notification/Notification(title, options)</a><span>, in §3</span>
@@ -856,6 +877,7 @@ interface <a href="#notification">Notification</a> : <a data-link-type="idl-name
   readonly attribute USVString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="USVString " href="#dom-notification-icon">icon</a>;
   readonly attribute USVString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="USVString " href="#dom-notification-sound">sound</a>;
   readonly attribute FrozenArray&lt;unsigned long> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<unsigned long> " href="#dom-notification-vibrate">vibrate</a>;
+  readonly attribute unsigned long long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long " href="#dom-notification-timestamp">timestamp</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-renotify">renotify</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-silent">silent</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-noscreen">noscreen</a>;
@@ -874,6 +896,7 @@ dictionary <a href="#dictdef-notificationoptions">NotificationOptions</a> {
   USVString <a data-type="USVString " href="#dom-notificationoptions-icon">icon</a>;
   USVString <a data-type="USVString " href="#dom-notificationoptions-sound">sound</a>;
   <a data-link-type="idl-name" href="http://www.w3.org/TR/vibration/#idl-def-VibratePattern">VibratePattern</a> <a data-type="VibratePattern " href="#dom-notificationoptions-vibrate">vibrate</a>;
+  unsigned long long <a data-type="unsigned long long " href="#dom-notificationoptions-timestamp">timestamp</a>;
   boolean <a data-default="false" data-type="boolean " href="#dom-notificationoptions-renotify">renotify</a> = false;
   boolean <a data-default="false" data-type="boolean " href="#dom-notificationoptions-silent">silent</a> = false;
   boolean <a data-default="false" data-type="boolean " href="#dom-notificationoptions-noscreen">noscreen</a> = false;


### PR DESCRIPTION
Fixes #20.

The `timestamp` of a notification is the time, in milliseconds since
the epoch, of the event for which the notification was created. Web
developers can use this if the time of this event does not match the
time at which the notification is being shown, which can be the case
when notifying the user of upcoming calendar events.

Note that the `Boilerplate` change in the meta-data is Tab's
suggestion in https://github.com/tabatkins/bikeshed/issues/470.