### PR TITLE
Change Notification.timestamp to be an unrestricted double instead

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -56,7 +56,7 @@ representing either a valid BCP 47 language tag or the empty string.
 <dfn>data</dfn>.
 
 <p>A <a lt="concept notification">notification</a> has an associated
-<dfn>timestamp</dfn> which is an unsigned long long representing the time, in
+<dfn>timestamp</dfn> which is an unrestricted double representing the time, in
 milliseconds since 00:00:00 UTC on 1 January 1970, of the event for which the
 notification was created.
 
@@ -168,8 +168,9 @@ or vibration pattern that is not otherwise accessible to the end user.
   <a>vibration pattern</a> to the return value. (Otherwise
   <a>vibration pattern</a> is not set.)
 
-  <li><p>If <var>options</var>'s <code>timestamp</code> is present, set
-  <var>notification</var>'s <a>timestamp</a> to the value. Otherwise, set
+  <li><p>If <var>options</var>'s <code>timestamp</code> is present and its
+  value is not <code>NaN</code>, <code>-Infinite</code> or <code>+Infinite</code>,
+  set <var>notification</var>'s <a>timestamp</a> to the value. Otherwise, set
   <var>notification</var>'s <a>timestamp</a> to the number of milliseconds that
   passed between 00:00:00 UTC on 1 January 1970 and the time at which the
   <code>Notification</code> constructor was called.
@@ -464,7 +465,7 @@ interface Notification : EventTarget {
   readonly attribute USVString icon;
   readonly attribute USVString sound;
   readonly attribute FrozenArray&lt;unsigned long> vibrate;
-  readonly attribute unsigned long long timestamp;
+  readonly attribute unrestricted double timestamp;
   readonly attribute boolean renotify;
   readonly attribute boolean silent;
   readonly attribute boolean noscreen;
@@ -483,7 +484,7 @@ dictionary NotificationOptions {
   USVString icon;
   USVString sound;
   VibratePattern vibrate;
-  unsigned long long timestamp;
+  unrestricted double timestamp;
   boolean renotify = false;
   boolean silent = false;
   boolean noscreen = false;

--- a/notifications.html
+++ b/notifications.html
@@ -11,7 +11,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-notifications.svg"> </a> </p>
    <h1 class="p-name no-ref" id="title">Notifications API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-10-14">14 October 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-10-21">21 October 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Participate:
@@ -94,8 +94,8 @@ representation of something that happened, such as the delivery of a message. </
 representing either a valid BCP 47 language tag or the empty string. </p>
    <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="tag">tag<a class="self-link" href="#tag"></a></dfn> which is a DOMString. </p>
    <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="data">data<a class="self-link" href="#data"></a></dfn>. </p>
-   <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="timestamp">timestamp<a class="self-link" href="#timestamp"></a></dfn> which is an unsigned long long representing the time in
-milliseconds since 00:00:00 UTC on 1 January 1970 of the event for which the
+   <p>A <a data-link-type="dfn" href="#concept-notification">notification</a> has an associated <dfn data-dfn-type="dfn" data-noexport="" id="timestamp">timestamp<a class="self-link" href="#timestamp"></a></dfn> which is an unrestricted double representing the time, in
+milliseconds since 00:00:00 UTC on 1 January 1970, of the event for which the
 notification was created. </p>
    <p class="note" role="note">Timestamps can be used to indicate the time at which a notification
 is actual. For example, this could be in the past when a notification is used for
@@ -157,7 +157,9 @@ or vibration pattern that is not otherwise accessible to the end user. </p>
     <li>
      <p>If <var>options</var>’s <code>vibrate</code> is present, <a data-link-type="dfn" href="http://www.w3.org/TR/vibration/#dfn-validate-and-normalize">validate and normalize</a> it and set <var>notification</var>’s <a data-link-type="dfn" href="#vibration-pattern">vibration pattern</a> to the return value. (Otherwise <a data-link-type="dfn" href="#vibration-pattern">vibration pattern</a> is not set.) </p>
     <li>
-     <p>If <var>options</var>’s <code>timestamp</code> is present, set <var>notification</var>’s <a data-link-type="dfn" href="#timestamp">timestamp</a> to the value. Otherwise, set <var>notification</var>’s <a data-link-type="dfn" href="#timestamp">timestamp</a> to the number of milliseconds that
+     <p>If <var>options</var>’s <code>timestamp</code> is present and its
+  value is not <code>NaN</code>, <code>-Infinite</code> or <code>+Infinite</code>,
+  set <var>notification</var>’s <a data-link-type="dfn" href="#timestamp">timestamp</a> to the value. Otherwise, set <var>notification</var>’s <a data-link-type="dfn" href="#timestamp">timestamp</a> to the number of milliseconds that
   passed between 00:00:00 UTC on 1 January 1970 and the time at which the <code>Notification</code> constructor was called. </p>
     <li>
      <p>If <var>options</var>’s <code>renotify</code> is true, set <var>notification</var>’s <a data-link-type="dfn" href="#renotify-preference-flag">renotify preference flag</a>. </p>
@@ -340,7 +342,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="not
   readonly attribute USVString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="USVString " href="#dom-notification-icon">icon</a>;
   readonly attribute USVString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="USVString " href="#dom-notification-sound">sound</a>;
   readonly attribute FrozenArray&lt;unsigned long> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<unsigned long> " href="#dom-notification-vibrate">vibrate</a>;
-  readonly attribute unsigned long long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long " href="#dom-notification-timestamp">timestamp</a>;
+  readonly attribute unrestricted double <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unrestricted double " href="#dom-notification-timestamp">timestamp</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-renotify">renotify</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-silent">silent</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-noscreen">noscreen</a>;
@@ -359,7 +361,7 @@ dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="d
   USVString <dfn class="idl-code" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-notificationoptions-icon">icon<a class="self-link" href="#dom-notificationoptions-icon"></a></dfn>;
   USVString <dfn class="idl-code" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-notificationoptions-sound">sound<a class="self-link" href="#dom-notificationoptions-sound"></a></dfn>;
   <a data-link-type="idl-name" href="http://www.w3.org/TR/vibration/#idl-def-VibratePattern">VibratePattern</a> <dfn class="idl-code" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="VibratePattern " id="dom-notificationoptions-vibrate">vibrate<a class="self-link" href="#dom-notificationoptions-vibrate"></a></dfn>;
-  unsigned long long <dfn class="idl-code" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="unsigned long long " id="dom-notificationoptions-timestamp">timestamp<a class="self-link" href="#dom-notificationoptions-timestamp"></a></dfn>;
+  unrestricted double <dfn class="idl-code" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="unrestricted double " id="dom-notificationoptions-timestamp">timestamp<a class="self-link" href="#dom-notificationoptions-timestamp"></a></dfn>;
   boolean <dfn class="idl-code" data-default="false" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-notificationoptions-renotify">renotify<a class="self-link" href="#dom-notificationoptions-renotify"></a></dfn> = false;
   boolean <dfn class="idl-code" data-default="false" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-notificationoptions-silent">silent<a class="self-link" href="#dom-notificationoptions-silent"></a></dfn> = false;
   boolean <dfn class="idl-code" data-default="false" data-dfn-for="NotificationOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-notificationoptions-noscreen">noscreen<a class="self-link" href="#dom-notificationoptions-noscreen"></a></dfn> = false;
@@ -877,7 +879,7 @@ interface <a href="#notification">Notification</a> : <a data-link-type="idl-name
   readonly attribute USVString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="USVString " href="#dom-notification-icon">icon</a>;
   readonly attribute USVString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="USVString " href="#dom-notification-sound">sound</a>;
   readonly attribute FrozenArray&lt;unsigned long> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="FrozenArray<unsigned long> " href="#dom-notification-vibrate">vibrate</a>;
-  readonly attribute unsigned long long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long long " href="#dom-notification-timestamp">timestamp</a>;
+  readonly attribute unrestricted double <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unrestricted double " href="#dom-notification-timestamp">timestamp</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-renotify">renotify</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-silent">silent</a>;
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-notification-noscreen">noscreen</a>;
@@ -896,7 +898,7 @@ dictionary <a href="#dictdef-notificationoptions">NotificationOptions</a> {
   USVString <a data-type="USVString " href="#dom-notificationoptions-icon">icon</a>;
   USVString <a data-type="USVString " href="#dom-notificationoptions-sound">sound</a>;
   <a data-link-type="idl-name" href="http://www.w3.org/TR/vibration/#idl-def-VibratePattern">VibratePattern</a> <a data-type="VibratePattern " href="#dom-notificationoptions-vibrate">vibrate</a>;
-  unsigned long long <a data-type="unsigned long long " href="#dom-notificationoptions-timestamp">timestamp</a>;
+  unrestricted double <a data-type="unrestricted double " href="#dom-notificationoptions-timestamp">timestamp</a>;
   boolean <a data-default="false" data-type="boolean " href="#dom-notificationoptions-renotify">renotify</a> = false;
   boolean <a data-default="false" data-type="boolean " href="#dom-notificationoptions-silent">silent</a> = false;
   boolean <a data-default="false" data-type="boolean " href="#dom-notificationoptions-noscreen">noscreen</a> = false;


### PR DESCRIPTION
Date.now() returns a value of the Number type, which maps to WebIDL's
unrestricted double. This allows timestamps in the entire range of
Date to be used, rather than just times after the unix epoch.