### PR TITLE
Update Vibration API references

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -1249,12 +1249,12 @@ urlPrefix: https://dom.spec.whatwg.org/; type: dfn
   text: dom event cancelable
 urlPrefix: https://dom.spec.whatwg.org/; type: interface
   text: EventTarget
-urlPrefix: https://www.w3.org/TR/vibration/
+urlPrefix: https://w3c.github.io/vibration/
   urlPrefix: #dfn-; type: dfn
     text: perform vibration
     text: validate and normalize
   urlPrefix: #idl-def-; type: interface
-    text: VibratePattern; url: VibratePattern
+    text: VibratePattern; url: vibratepattern
 urlPrefix: https://tc39.github.io/ecma262/#sec-object.; type: dfn
   text: freeze
 </pre>


### PR DESCRIPTION
The Vibration API ED migrated from W3C CVS to GitHub. In the process we applied Rec errata to the ED. This PR updates the Vibration API references accordingly as follows:

* https://www.w3.org/TR/vibration/#dfn-validate-and-normalize -> https://w3c.github.io/vibration/#dfn-validate-and-normalize
* https://www.w3.org/TR/vibration/#dfn-perform-vibration -> https://w3c.github.io/vibration/#dfn-perform-vibration
* https://www.w3.org/TR/vibration/#idl-def-VibratePattern -> https://w3c.github.io/vibration/#idl-def-vibratepattern

I'm trying to get the Specref [VIBRATION] reference updated similarly as well, see https://lists.w3.org/Archives/Public/spec-prod/2016AprJun/0012.html