### PR TITLE
Multiple icon definitions

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -617,7 +617,8 @@ bandwidth.
 <ol>
   <li><p>Let <var>selectedURL</var> and <var>selectedIcon</var> be null.
 
-  <li><p>For each <var>icon</var> in <var>icons</var> run these substeps:
+  <li>
+    <p>For each <var>icon</var> in <var>icons</var> run these substeps:
 
     <ol>
       <li>

--- a/notifications.bs
+++ b/notifications.bs
@@ -202,15 +202,17 @@ these steps:
   <li><p>Let <var>baseURL</var> be the API base URL specified by the
   <a>entry settings object</a>. <span class=XXX>Or incumbent?</span>
 
-  <li><p>If <var>options</var>'s <code>icon</code> is present,
-  <a lt="url parser">parse</a> it using <var>baseURL</var>, and if that does not
-  return failure, set <var>notification</var>'s <a>icon URL</a> to the return
-  value. (Otherwise <a>icon URL</a> is not set.)
+  <li><p>Run the <a>icon URL selection steps</a>, providing <var>options</var>'s
+  <code>icons</code>, <var>options</var>'s <code>icon</code>, and
+  <var>baseURL</var>, and if that does not return null, set
+  <var>notification</var>'s <a>icon URL</a> to the return value. (Otherwise
+  <a>icon URL</a> is not set.)
 
-  <li><p>If <var>options</var>'s <code>badge</code> is present,
-  <a lt="url parser">parse</a> it using <var>baseURL</var>, and if that does not
-  return failure, set <var>notification</var>'s <a>badge URL</a> to the return
-  value. (Otherwise <a>badge URL</a> is not set.)
+  <li><p>Run the <a>icon URL selection steps</a>, providing <var>options</var>'s
+  <code>badges</code>, <var>options</var>'s <code>badge</code>, and
+  <var>baseURL</var>, and if that does not return null, set
+  <var>notification</var>'s <a>badge URL</a> to the return value. (Otherwise
+  <a>badge URL</a> is not set.)
 
   <li><p>If <var>options</var>'s <code>sound</code> is present,
   <a lt="url parser">parse</a> it using <var>baseURL</var>, and if that does not
@@ -257,10 +259,11 @@ these steps:
     <li><p>Set <var>action</var>'s <a lt="action title">title</a> to the
     <var>entry</var>'s <code>title</code>.
 
-    <li><p>If <var>entry</var>'s <code>icon</code> is present,
-    <a lt="url parser">parse</a> it using <var>baseURL</var>, and if that does
-    not return failure, set <var>action</var>'s <a>action icon URL</a> to the
-    return value. (Otherwise <a>action icon URL</a> is not set.)
+    <li><p>Run the <a>icon URL selection steps</a>, providing <var>entry</var>'s
+    <code>icons</code>, <var>entry</var>'s <code>icon</code>, and
+    <var>baseURL</var>, and if that does not return null, set
+    <var>actions</var>'s <a>action icon URL</a> to the return value. (Otherwise
+    <a>action icon URL</a> is not set.)
 
     <li><p>Append <var>action</var> to <var>notification</var>'s list of
     <a>actions</a>.
@@ -601,6 +604,39 @@ or vibrating the device again, unless the <a>renotify preference flag</a> is set
 </ol>
 
 
+<h3 id=selecting-an-icon-url>Selecting an icon URL</h3>
+
+<p>The <dfn>icon URL selection steps</dfn> for selecting a URL given a list <var>icons</var> of type
+{{NotificationIcon}}, a <var>fallbackURLString</var> of type {{USVString}}, and
+<a lt="base url">base URL</a> <var>baseURL</var> are:
+
+<ol>
+  <li><p>Let <var>selectedURL</var> and <var>selectedIcon</var> be null
+
+  <li><p>For each <var>icon</var> in <var>icons</var> run these substeps:
+
+  <ol>
+    <li><p>Let <var>iconURL</var> be the result of <a lt="url parser">parsing</a> <var>icon</var>'s
+    <code>src</code> using <var>baseURL</var>. If <var>iconURL</var> is failure, abort these
+    substeps for this <var>icon</var>
+
+    <li><p>Let <var>parsedSizes</var> be the result of <a lt="attr link sizes">parsing</a>
+    <var>icon</var>'s <code>sizes</code>
+
+    <li><p>If <var>icon</var> is considered by the implementation to be more suitable than
+    <var>selectedIcon</var>, taking into account whether <var>icon</var>'s <code>type</code> is
+    <a lt="valid mime type">valid</a> and <a lt="resources">supported</a>, as well as the value of
+    <var>parsedSizes</var>, then set <var>selectedURL</var> to <var>iconURL</var> and set
+    <var>selectedIcon</var> to <var>icon</var>
+  </ol>
+
+  <li><p>If <var>selectedURL</var> is null, <a lt="url parser">parse</a>
+  <var>fallbackURLString</var> using <var>baseURL</var>, and if that does not return failure, set
+  <var>selectedURL</var> to the return value
+
+  <li><p>Return <var>selectedURL</var>
+</ol>
+
 <h2 id=api>API</h2>
 
 <pre class=idl>
@@ -621,7 +657,9 @@ interface Notification : EventTarget {
   readonly attribute DOMString body;
   readonly attribute DOMString tag;
   readonly attribute USVString icon;
+  [SameObject] readonly attribute FrozenArray&lt;NotificationIcon> icons;
   readonly attribute USVString badge;
+  [SameObject] readonly attribute FrozenArray&lt;NotificationIcon> badges;
   readonly attribute USVString sound;
   [SameObject] readonly attribute FrozenArray&lt;unsigned long> vibrate;
   readonly attribute DOMTimeStamp timestamp;
@@ -642,7 +680,9 @@ dictionary NotificationOptions {
   DOMString body = "";
   DOMString tag = "";
   USVString icon;
+  sequence&lt;NotificationIcon> icons = [];
   USVString badge;
+  sequence&lt;NotificationIcon> badges = [];
   USVString sound;
   VibratePattern vibrate;
   DOMTimeStamp timestamp;
@@ -671,6 +711,13 @@ dictionary NotificationAction {
   required DOMString action;
   required DOMString title;
   USVString icon;
+  sequence&lt;NotificationIcon> icons = [];
+};
+
+dictionary NotificationIcon {
+  required USVString src;
+  DOMString type;
+  DOMString sizes;
 };
 
 callback NotificationPermissionCallback = void (NotificationPermission permission);
@@ -1213,9 +1260,13 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
     text: Window
   urlPrefix: infrastructure.html; type: dfn
     text: in parallel
+    text: valid mime type
+    text: resources
   urlPrefix: interaction.html; type: dfn
     text: dom window focus
     text: structured clone
+  urlPrefix: semantics.html; type: dfn
+    text: attr link sizes
   urlPrefix: webappapis.html; type: dfn
     text: entry settings object
     text: event handler event types
@@ -1226,6 +1277,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
   urlPrefix: webappapis.html; type: interface
     text: EventHandler
 urlPrefix: https://url.spec.whatwg.org/#concept-; type: dfn
+  text: base url
   text: url parser
   text: url serializer
 urlPrefix: https://fetch.spec.whatwg.org/#concept-; type: dfn

--- a/notifications.bs
+++ b/notifications.bs
@@ -606,35 +606,43 @@ or vibrating the device again, unless the <a>renotify preference flag</a> is set
 
 <h3 id=selecting-an-icon-url>Selecting an icon URL</h3>
 
+<p>The user agent should select the most suitable icon while balancing multiple goals and
+constraints: high quality icon display, screen size, and availability of resources like memory and
+bandwidth.
+
 <p>The <dfn>icon URL selection steps</dfn> for selecting a URL given a list <var>icons</var> of type
-{{NotificationIcon}}, a <var>fallbackURLString</var> of type {{USVString}}, and
+{{NotificationIconOptions}}, a <var>fallbackURLString</var> of type {{USVString}}, and
 <a lt="base url">base URL</a> <var>baseURL</var> are:
 
 <ol>
-  <li><p>Let <var>selectedURL</var> and <var>selectedIcon</var> be null
+  <li><p>Let <var>selectedURL</var> and <var>selectedIcon</var> be null.
 
   <li><p>For each <var>icon</var> in <var>icons</var> run these substeps:
 
-  <ol>
-    <li><p>Let <var>iconURL</var> be the result of <a lt="url parser">parsing</a> <var>icon</var>'s
-    <code>src</code> using <var>baseURL</var>. If <var>iconURL</var> is failure, abort these
-    substeps for this <var>icon</var>
+    <ol>
+      <li>
+        <p>Let <var>iconURL</var> be the result of <a lt="url parser">parsing</a> <var>icon</var>'s
+        <code>src</code> using <var>baseURL</var>. If <var>iconURL</var> is failure, abort these
+        substeps for this <var>icon</var>.
 
-    <li><p>Let <var>parsedSizes</var> be the result of <a lt="attr link sizes">parsing</a>
-    <var>icon</var>'s <code>sizes</code>
+      <li>
+        <p>Let <var>parsedSizes</var> be the result of <a lt="attr link sizes">parsing</a>
+        <var>icon</var>'s <code>sizes</code>.
 
-    <li><p>If <var>icon</var> is considered by the implementation to be more suitable than
-    <var>selectedIcon</var>, taking into account whether <var>icon</var>'s <code>type</code> is
-    <a lt="valid mime type">valid</a> and <a lt="resources">supported</a>, as well as the value of
-    <var>parsedSizes</var>, then set <var>selectedURL</var> to <var>iconURL</var> and set
-    <var>selectedIcon</var> to <var>icon</var>
-  </ol>
+      <li>
+        <p>If <var>icon</var> is considered by the implementation to be more suitable than
+        <var>selectedIcon</var>, taking into account whether <var>icon</var>'s <code>type</code> is
+        <a lt="valid mime type">valid</a> and <a lt="resources">supported</a>, as well as the value
+        of <var>parsedSizes</var>, then set <var>selectedURL</var> to <var>iconURL</var> and set
+        <var>selectedIcon</var> to <var>icon</var>.
+    </ol>
 
-  <li><p>If <var>selectedURL</var> is null, <a lt="url parser">parse</a>
-  <var>fallbackURLString</var> using <var>baseURL</var>, and if that does not return failure, set
-  <var>selectedURL</var> to the return value
+  <li>
+    <p>If <var>selectedURL</var> is null, <a lt="url parser">parse</a>
+    <var>fallbackURLString</var> using <var>baseURL</var>, and if that does not return failure, set
+    <var>selectedURL</var> to the return value.
 
-  <li><p>Return <var>selectedURL</var>
+  <li><p>Return <var>selectedURL</var>.
 </ol>
 
 <h2 id=api>API</h2>
@@ -657,9 +665,7 @@ interface Notification : EventTarget {
   readonly attribute DOMString body;
   readonly attribute DOMString tag;
   readonly attribute USVString icon;
-  [SameObject] readonly attribute FrozenArray&lt;NotificationIcon> icons;
   readonly attribute USVString badge;
-  [SameObject] readonly attribute FrozenArray&lt;NotificationIcon> badges;
   readonly attribute USVString sound;
   [SameObject] readonly attribute FrozenArray&lt;unsigned long> vibrate;
   readonly attribute DOMTimeStamp timestamp;
@@ -680,9 +686,9 @@ dictionary NotificationOptions {
   DOMString body = "";
   DOMString tag = "";
   USVString icon;
-  sequence&lt;NotificationIcon> icons = [];
+  sequence&lt;NotificationIconOptions> icons = [];
   USVString badge;
-  sequence&lt;NotificationIcon> badges = [];
+  sequence&lt;NotificationIconOptions> badges = [];
   USVString sound;
   VibratePattern vibrate;
   DOMTimeStamp timestamp;
@@ -692,7 +698,7 @@ dictionary NotificationOptions {
   boolean requireInteraction = false;
   boolean sticky = false;
   any data = null;
-  sequence&lt;NotificationAction> actions = [];
+  sequence&lt;NotificationActionOptions> actions = [];
 };
 
 enum NotificationPermission {
@@ -707,14 +713,20 @@ enum NotificationDirection {
   "rtl"
 };
 
-dictionary NotificationAction {
+interface NotificationAction {
+  readonly attribute DOMString action;
+  readonly attribute DOMString title;
+  readonly attribute USVString icon;
+};
+
+dictionary NotificationActionOptions {
   required DOMString action;
   required DOMString title;
   USVString icon;
-  sequence&lt;NotificationIcon> icons = [];
+  sequence&lt;NotificationIconOptions> icons = [];
 };
 
-dictionary NotificationIcon {
+dictionary NotificationIconOptions {
   required USVString src;
   DOMString type;
   DOMString sizes;
@@ -933,8 +945,7 @@ getter must return a <a>structured clone</a> of
 attribute's getter must return the result of the following steps:
 
 <ol>
-  <li><p>Let <var>frozenActions</var> be an empty list of type
-  {{NotificationAction}}.
+  <li><p>Let <var>list</var> be an empty list of type {{NotificationAction}}.
 
   <li><p>For each <var>entry</var> in the
   <a lt="concept notification">notification</a>'s list of <a>actions</a>,
@@ -952,19 +963,11 @@ attribute's getter must return the result of the following steps:
     <li><p>Set <var>action</var>'s {{NotificationAction/icon}} to
     <var>entry</var>'s <a>action icon URL</a>.
 
-    <!-- XXX IDL dictionaries are usually returned by value, so don't need to be
-         immutable. But FrozenArray reifies the dictionaries to mutable JS
-         objects accessed by reference, so we explicitly freeze them.
-         It would be better to do this with IDL primitives instead of JS - see
-         https://www.w3.org/Bugs/Public/show_bug.cgi?id=29004 -->
-    <li><p>Call <a lt="freeze">Object.freeze</a> on <var>action</var>, to
-    prevent accidental mutation by scripts.
-
-    <li><p>Append <var>action</var> to <var>frozenActions</var>.
+    <li><p>Append <var>action</var> to <var>list</var>.
   </ol>
 
   <li><p><a lt="create frozen array">Create a frozen array</a> from
-  <var>frozenActions</var>.
+  <var>list</var>.
 </ol>
 
 <h3 id=examples>Examples</h3>
@@ -1309,8 +1312,6 @@ urlPrefix: https://w3c.github.io/vibration/
     text: validate and normalize
   urlPrefix: #idl-def-; type: interface
     text: VibratePattern; url: vibratepattern
-urlPrefix: https://tc39.github.io/ecma262/#sec-object.; type: dfn
-  text: freeze
 </pre>
 
 <pre class="biblio">


### PR DESCRIPTION
I think the initial patch has the general shape of what I want to do for #28.

I did find there's two ways we could go with the attribute getters on a notification, for example for the icon. To me it's not clear whether we need a single `icon` getter that reflects the selected url, or both `icon` and `icons` which reflect the exact input from options.

Previously `icon` reflected a serialization of the options `icon` input that was parsed with baseURL, not the exact original input. That means, for example, that if parsing fails, the getter returns the empty string. The implications for `NotificationIcon` are not clear to me: would invalid input such as for `type` or `sizes` need to be dropped in the same way? That might surprise developers.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/76.html" title="Last updated on Jan 15, 2021, 7:46 AM UTC (54dd556)">Preview</a> | <a href="https://whatpr.org/notifications/76/41843b5...54dd556.html" title="Last updated on Jan 15, 2021, 7:46 AM UTC (54dd556)">Diff</a>