### PR TITLE
Add note about intent of fetching

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -375,90 +375,116 @@ interpreted as a language tag. Validity or well-formedness are not enforced. [[!
 <a>notification</a> <var>notification</var> are:
 
 <ol>
-  <!-- XXX https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055 -->
-  <li><p>If the notification platform supports images, <a for=/>fetch</a>
+ <!-- XXX https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055 -->
+ <li>
+  <p>If the notification platform supports images, <a for=/>fetch</a>
   <var>notification</var>'s <a>image URL</a>, if <a>image URL</a> is set.
 
-  <p>Then, <a>in parallel</a>:
-
-  <ol>
-    <li><p>Wait for the <a for=/>response</a>.
-
-    <li><p>If the <a for=/>response</a>'s <a>internal response</a>'s <a for=response>type</a> is
-    "<code>default</code>", then attempt to decode the resource as image.
-
-    <li><p>If the image format is supported, set <var>notification</var>'s
-    <a>image resource</a> to the decoded resource. (Otherwise
-    <var>notification</var> has no <a>image resource</a>.)
-  </ol>
-
-  <li><p>If the notification platform supports icons, <a for=/>fetch</a>
-  <var>notification</var>'s <a for=notification>icon URL</a>, if <a for=notification>icon URL</a> is set.
+  <p class=note>The intent is to fetch this resource similar to an
+  <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
+  but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>.
 
   <p>Then, <a>in parallel</a>:
 
   <ol>
-    <li><p>Wait for the <a for=/>response</a>.
+   <li><p>Wait for the <a for=/>response</a>.
 
-    <li><p>If the <a for=/>response</a>'s <a>internal response</a>'s <a for=response>type</a> is
-    "<code>default</code>", then attempt to decode the resource as image.
+   <li><p>If the <a for=/>response</a>'s <a>internal response</a>'s <a for=response>type</a> is
+   "<code>default</code>", then attempt to decode the resource as image.
 
-    <li><p>If the image format is supported, set <var>notification</var>'s
-    <a for=notification>icon resource</a> to the decoded resource. (Otherwise
-    <var>notification</var> has no <a for=notification>icon resource</a>.)
+   <li><p>If the image format is supported, set <var>notification</var>'s
+   <a>image resource</a> to the decoded resource. (Otherwise
+   <var>notification</var> has no <a>image resource</a>.)
   </ol>
 
-  <li><p>If the notification platform supports badges, <a for=/>fetch</a>
-  <var>notification</var>'s <a for=notification>badge URL</a>, if <a for=notification>badge URL</a> is set.
+ <li>
+  <p>If the notification platform supports icons, <a for=/>fetch</a>
+  <var>notification</var>'s <a for=notification>icon URL</a>, if <a for=notification>icon URL</a>
+  is set.
+
+  <p class=note>The intent is to fetch this resource similar to an
+  <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
+  but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>.
 
   <p>Then, <a>in parallel</a>:
 
   <ol>
-    <li><p>Wait for the <a for=/>response</a>.
+   <li><p>Wait for the <a for=/>response</a>.
 
-    <li><p>If the <a for=/>response</a>'s <a>internal response</a>'s <a for=response>type</a> is
-    "<code>default</code>", then attempt to decode the resource as image.
+   <li><p>If the <a for=/>response</a>'s <a>internal response</a>'s <a for=response>type</a> is
+   "<code>default</code>", then attempt to decode the resource as image.
 
-    <li><p>If the image format is supported, set <var>notification</var>'s
-    <a for=notification>badge resource</a> to the decoded resource. (Otherwise
-    <var>notification</var> has no <a for=notification>badge resource</a>.)
+   <li><p>If the image format is supported, set <var>notification</var>'s
+   <a for=notification>icon resource</a> to the decoded resource. (Otherwise
+   <var>notification</var> has no <a for=notification>icon resource</a>.)
   </ol>
+ </li>
 
-  <li><p>If the notification platform supports actions and action icons, then
-  for each <var>action</var> in <var>notification</var>'s list of <a>actions</a>
-  <a for=/>fetch</a> <var>action</var>'s <a for=action>icon URL</a>, if
-  <a for=action>icon URL</a> is set.
+ <li>
+  <p>If the notification platform supports badges, <a for=/>fetch</a> <var>notification</var>'s
+  <a for=notification>badge URL</a>, if <a for=notification>badge URL</a> is set.
+
+  <p class=note>The intent is to fetch this resource similar to an
+  <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
+  but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>.
 
   <p>Then, <a>in parallel</a>:
 
   <ol>
-    <li><p>Wait for the <a for=/>response</a>.
+   <li><p>Wait for the <a for=/>response</a>.
 
-    <li><p>If the <a for=/>response</a>'s <a>internal response</a>'s <a for=response>type</a> is
-    "<code>default</code>", then attempt to decode the resource as image.
+   <li><p>If the <a for=/>response</a>'s <a>internal response</a>'s <a for=response>type</a> is
+   "<code>default</code>", then attempt to decode the resource as image.
 
-    <li><p>If the image format is supported, set <var>action</var>'s
-    <a for=action>icon resource</a> to the decoded resource. (Otherwise
-    <var>action</var> has no <a for=action>icon resource</a>.)
+   <li><p>If the image format is supported, set <var>notification</var>'s
+   <a for=notification>badge resource</a> to the decoded resource. (Otherwise
+   <var>notification</var> has no <a for=notification>badge resource</a>.)
   </ol>
+ </li>
 
-  <li><p>If the notification platform supports sounds, and the <var>notification</var>
-  is either not <a>replaceable</a> or has the <a for=notification>renotify preference flag</a> set,
-  <a for=/>fetch</a> <var>notification</var>'s <a for=notification>sound URL</a> if it has been set.
+ <li>
+  <p>If the notification platform supports actions and action icons, then for each <var>action</var>
+  in <var>notification</var>'s list of <a>actions</a> <a for=/>fetch</a> <var>action</var>'s
+  <a for=action>icon URL</a>, if <a for=action>icon URL</a> is set.
+
+  <p class=note>The intent is to fetch this resource similar to an
+  <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
+  but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>.
 
   <p>Then, <a>in parallel</a>:
 
   <ol>
-    <li><p>Wait for the <a for=/>response</a>.
+   <li><p>Wait for the <a for=/>response</a>.
 
-    <li><p>If the <a for=/>response</a>'s <a>internal response</a>'s <a for=response>type</a> is
-    "<code>default</code>", then attempt to decode the resource as sound.
-    <!-- XXX xref -->
+   <li><p>If the <a for=/>response</a>'s <a>internal response</a>'s <a for=response>type</a> is
+   "<code>default</code>", then attempt to decode the resource as image.
 
-    <li><p>If the sound format is supported, set <var>notification</var>'s
-    <a>sound resource</a> to the decoded resource. (Otherwise
-    <var>notification</var> has no <a>sound resource</a>.)
+   <li><p>If the image format is supported, set <var>action</var>'s
+   <a for=action>icon resource</a> to the decoded resource. (Otherwise
+   <var>action</var> has no <a for=action>icon resource</a>.)
   </ol>
+ </li>
+
+ <li>
+  <p>If the notification platform supports sounds, and the <var>notification</var>
+  is either not <a>replaceable</a> or has the <a for=notification>renotify preference flag</a>
+  set, <a for=/>fetch</a> <var>notification</var>'s <a for=notification>sound URL</a> if it has
+  been set.
+
+  <p>Then, <a>in parallel</a>:
+
+  <ol>
+   <li><p>Wait for the <a for=/>response</a>.
+
+   <li><p>If the <a for=/>response</a>'s <a>internal response</a>'s <a for=response>type</a> is
+   "<code>default</code>", then attempt to decode the resource as sound.
+   <!-- XXX xref -->
+
+   <li><p>If the sound format is supported, set <var>notification</var>'s
+   <a>sound resource</a> to the decoded resource. (Otherwise
+   <var>notification</var> has no <a>sound resource</a>.)
+  </ol>
+ </li>
 </ol>
 
 

--- a/notifications.html
+++ b/notifications.html
@@ -340,62 +340,70 @@ interpreted as a language tag. Validity or well-formedness are not enforced. <a 
    <ol>
     <li>
      <p>If the notification platform supports images, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> <var>notification</var>’s <a data-link-type="dfn" href="#image-url">image URL</a>, if <a data-link-type="dfn" href="#image-url">image URL</a> is set. </p>
+     <p class="note" role="note">The intent is to fetch this resource similar to an <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img></code></a>,
+  but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>. </p>
      <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: </p>
      <ol>
       <li>
        <p>Wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>. </p>
       <li>
        <p>If the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-internal-response">internal response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is
-    "<code>default</code>", then attempt to decode the resource as image. </p>
+   "<code>default</code>", then attempt to decode the resource as image. </p>
       <li>
        <p>If the image format is supported, set <var>notification</var>’s <a data-link-type="dfn" href="#image-resource">image resource</a> to the decoded resource. (Otherwise <var>notification</var> has no <a data-link-type="dfn" href="#image-resource">image resource</a>.) </p>
      </ol>
     <li>
      <p>If the notification platform supports icons, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> <var>notification</var>’s <a data-link-type="dfn" href="#icon-url">icon URL</a>, if <a data-link-type="dfn" href="#icon-url">icon URL</a> is set. </p>
+     <p class="note" role="note">The intent is to fetch this resource similar to an <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img></code></a>,
+  but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>. </p>
      <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: </p>
      <ol>
       <li>
        <p>Wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>. </p>
       <li>
        <p>If the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-internal-response">internal response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is
-    "<code>default</code>", then attempt to decode the resource as image. </p>
+   "<code>default</code>", then attempt to decode the resource as image. </p>
       <li>
        <p>If the image format is supported, set <var>notification</var>’s <a data-link-type="dfn" href="#icon-resource">icon resource</a> to the decoded resource. (Otherwise <var>notification</var> has no <a data-link-type="dfn" href="#icon-resource">icon resource</a>.) </p>
      </ol>
     <li>
      <p>If the notification platform supports badges, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> <var>notification</var>’s <a data-link-type="dfn" href="#badge-url">badge URL</a>, if <a data-link-type="dfn" href="#badge-url">badge URL</a> is set. </p>
+     <p class="note" role="note">The intent is to fetch this resource similar to an <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img></code></a>,
+  but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>. </p>
      <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: </p>
      <ol>
       <li>
        <p>Wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>. </p>
       <li>
        <p>If the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-internal-response">internal response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is
-    "<code>default</code>", then attempt to decode the resource as image. </p>
+   "<code>default</code>", then attempt to decode the resource as image. </p>
       <li>
        <p>If the image format is supported, set <var>notification</var>’s <a data-link-type="dfn" href="#badge-resource">badge resource</a> to the decoded resource. (Otherwise <var>notification</var> has no <a data-link-type="dfn" href="#badge-resource">badge resource</a>.) </p>
      </ol>
     <li>
-     <p>If the notification platform supports actions and action icons, then
-  for each <var>action</var> in <var>notification</var>’s list of <a data-link-type="dfn" href="#actions">actions</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> <var>action</var>’s <a data-link-type="dfn" href="#action-icon-url">icon URL</a>, if <a data-link-type="dfn" href="#action-icon-url">icon URL</a> is set. </p>
+     <p>If the notification platform supports actions and action icons, then for each <var>action</var> in <var>notification</var>’s list of <a data-link-type="dfn" href="#actions">actions</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> <var>action</var>’s <a data-link-type="dfn" href="#action-icon-url">icon URL</a>, if <a data-link-type="dfn" href="#action-icon-url">icon URL</a> is set. </p>
+     <p class="note" role="note">The intent is to fetch this resource similar to an <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img></code></a>,
+  but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>. </p>
      <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: </p>
      <ol>
       <li>
        <p>Wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>. </p>
       <li>
        <p>If the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-internal-response">internal response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is
-    "<code>default</code>", then attempt to decode the resource as image. </p>
+   "<code>default</code>", then attempt to decode the resource as image. </p>
       <li>
        <p>If the image format is supported, set <var>action</var>’s <a data-link-type="dfn" href="#action-icon-resource">icon resource</a> to the decoded resource. (Otherwise <var>action</var> has no <a data-link-type="dfn" href="#action-icon-resource">icon resource</a>.) </p>
      </ol>
     <li>
-     <p>If the notification platform supports sounds, and the <var>notification</var> is either not <a data-link-type="dfn" href="#replaceable">replaceable</a> or has the <a data-link-type="dfn" href="#renotify-preference-flag">renotify preference flag</a> set, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> <var>notification</var>’s <a data-link-type="dfn" href="#sound-url">sound URL</a> if it has been set. </p>
+     <p>If the notification platform supports sounds, and the <var>notification</var> is either not <a data-link-type="dfn" href="#replaceable">replaceable</a> or has the <a data-link-type="dfn" href="#renotify-preference-flag">renotify preference flag</a> set, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> <var>notification</var>’s <a data-link-type="dfn" href="#sound-url">sound URL</a> if it has
+  been set. </p>
      <p>Then, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: </p>
      <ol>
       <li>
        <p>Wait for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>. </p>
       <li>
        <p>If the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-internal-response">internal response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is
-    "<code>default</code>", then attempt to decode the resource as sound. </p>
+   "<code>default</code>", then attempt to decode the resource as sound. </p>
       <li>
        <p>If the sound format is supported, set <var>notification</var>’s <a data-link-type="dfn" href="#sound-resource">sound resource</a> to the decoded resource. (Otherwise <var>notification</var> has no <a data-link-type="dfn" href="#sound-resource">sound resource</a>.) </p>
      </ol>


### PR DESCRIPTION
There's a link as an HTML comment, but feels like it should be visible when reading the spec.