### PR TITLE
Improve wording of the upfront-permission-request warning

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -814,9 +814,9 @@ method, when invoked, must run these steps:
  <li><p>Return <var>promise</var>.
 </ol>
 
-<p class="warning">In designing the platform notifications are the one instance
-thus far where asking the user upfront makes sense. Specifications for other
-APIs should not use this pattern and instead employ one of the
+<p class="warning">Notifications are the one instance thus far where asking the
+user upfront makes sense. Specifications for other APIs should not use this
+pattern and instead employ one of the
 <a href="http://robert.ocallahan.org/2011/06/permissions-for-web-applications_30.html">
 many more suitable alternatives</a>.
 


### PR DESCRIPTION
Fixes #95


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/beverloo/notifications/wording-fix.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/notifications/8eaabd2...beverloo:1779473.html)