### PR TITLE
Meta: update broken link to HTML's "update the image data"

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -370,7 +370,7 @@ interpreted as a language tag. Validity or well-formedness are not enforced. [[!
   <var>notification</var>'s <a>image URL</a>, if <a>image URL</a> is set.
 
   <p class=note>The intent is to fetch this resource similar to an
-  <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
+  <a href="https://html.spec.whatwg.org/multipage/images.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
   but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>.
 
   <p>Then, <a>in parallel</a>:
@@ -392,7 +392,7 @@ interpreted as a language tag. Validity or well-formedness are not enforced. [[!
   is set.
 
   <p class=note>The intent is to fetch this resource similar to an
-  <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
+  <a href="https://html.spec.whatwg.org/multipage/images.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
   but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>.
 
   <p>Then, <a>in parallel</a>:
@@ -414,7 +414,7 @@ interpreted as a language tag. Validity or well-formedness are not enforced. [[!
   <a for=notification>badge URL</a>, if <a for=notification>badge URL</a> is set.
 
   <p class=note>The intent is to fetch this resource similar to an
-  <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
+  <a href="https://html.spec.whatwg.org/multipage/images.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
   but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>.
 
   <p>Then, <a>in parallel</a>:
@@ -437,7 +437,7 @@ interpreted as a language tag. Validity or well-formedness are not enforced. [[!
   <a for=action>icon URL</a>, if <a for=action>icon URL</a> is set.
 
   <p class=note>The intent is to fetch this resource similar to an
-  <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
+  <a href="https://html.spec.whatwg.org/multipage/images.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
   but this <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=24055">needs abstracting</a>.
 
   <p>Then, <a>in parallel</a>:

--- a/notifications.bs
+++ b/notifications.bs
@@ -99,7 +99,7 @@ not enough space to display the <a>notification</a> itself. It <em>may</em> also
 the <a>notification</a>, but then it should have less visual priority than the
 <a for=notification>image resource</a> and <a for=notification>icon resource</a>.
 
-<p>A <a>notification</a> <em>can</em> have an <dfn for=notification id=sound-url>sound URL</dfn>,
+<p>A <a>notification</a> <em>can</em> have a <dfn for=notification id=sound-url>sound URL</dfn>,
 <dfn for=notification id=sound-resource>sound resource</dfn>,
 <dfn for=notification id=vibration-pattern>vibration pattern</dfn>.
 
@@ -323,8 +323,7 @@ for the application to ask for <a>permission</a>.
 section of HTML. [[!HTML]]
 
 <!-- keep this in sync with
-     https://html.spec.whatwg.org/multipage/rendering.html#text-rendered-in-native-user-interfaces
-     except spell "behaviour" as "behavior" -->
+     https://html.spec.whatwg.org/multipage/rendering.html#text-rendered-in-native-user-interfaces -->
 
 <p>User agents are expected to honor the Unicode semantics of the text of a
 <a>notification</a>'s <a for=notification>title</a>, <a for=notification>body</a>, and the


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/104.html" title="Last updated on Feb 27, 2018, 11:18 AM GMT (5a8fbde)">Preview</a> | <a href="https://whatpr.org/notifications/104/4a296ed...5a8fbde.html" title="Last updated on Feb 27, 2018, 11:18 AM GMT (5a8fbde)">Diff</a>