### PR TITLE
Add a warning about the reliability of the notificationclose event

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -582,6 +582,10 @@ must be run.
   <li><p>Remove <var>notification</var> from the <a>list of notifications</a>.
 </ol>
 
+<p class="warning">Because not all notification centers reliably dispatch an event when a
+notification is closed, the <code>notificationclose</code> event will be delivered on a best-effort
+basis. User agents should aim to support the event whenever possible.
+
 
 <h3 id=displaying-notification>Displaying notifications</h3>
 


### PR DESCRIPTION
Not all platforms dispatch an event to the applications (e.g. the user
agent) when a notification is dismissed, or only do so in a subset of
cases. This means that the `notificationclose` event is a best-effort
event. It adds significant value to the developer, as dismissal is a
powerful (yet complicated) signal, so user agents should still make an
effort to support it where they can.

Fixes #109


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/111.html" title="Last updated on Jan 15, 2021, 7:46 AM UTC (8e39f86)">Preview</a> | <a href="https://whatpr.org/notifications/111/439a225...8e39f86.html" title="Last updated on Jan 15, 2021, 7:46 AM UTC (8e39f86)">Diff</a>