### PR TITLE
Remove remaining mention of sound

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -70,7 +70,7 @@ run.
 
 <p>A <a>notification</a> has an associated
 <dfn for=notification id=silent-preference-flag>silent preference flag</dfn> which is initially
-unset. When set indicates that no sounds or vibrations should be made.
+unset. When set indicates that no vibrations should be performed.
 
 <p>A <a>notification</a> has an associated
 <dfn for=notification id=require-interaction-preference-flag>require interaction preference flag</dfn>


### PR DESCRIPTION
Looks like this was missed in #127. Use the same terminology as in [Alerting the user](https://notifications.spec.whatwg.org/#alerting-the-user) (*perform* a vibration instead of *make* a vibration).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/130.html" title="Last updated on Apr 13, 2018, 1:20 AM GMT (d7bd805)">Preview</a> | <a href="https://whatpr.org/notifications/130/e9407eb...d7bd805.html" title="Last updated on Apr 13, 2018, 1:20 AM GMT (d7bd805)">Diff</a>