### PR TITLE
Add support for inline replies

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -534,7 +534,8 @@ interpreted as a language tag. Validity or well-formedness are not enforced. [[!
 
 <p class="note">User agents are required to attribute notifications to the origin they
 are associated with. This reduces the possibility of phishing attacks where a notification has been
-designed to look like it originates from another origin.
+designed to look like it originates from another origin. The user should be aware that data entered
+into the notification will be made available to the attributed origin.
 
 <h3 id=activating-a-notification>Activating a notification</h3>
 


### PR DESCRIPTION
This change adds support for notifications that accept text input within their UI, aka 'inline replies'.

Explainer: https://github.com/anitawoodruff/inline-notification-replies

Requesting TAG review shortly, will link to it below.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/132.html" title="Last updated on Jan 15, 2021, 7:46 AM UTC (713eafb)">Preview</a> | <a href="https://whatpr.org/notifications/132/e9407eb...713eafb.html" title="Last updated on Jan 15, 2021, 7:46 AM UTC (713eafb)">Diff</a>