### PR TITLE
Simplifying functional events

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -522,13 +522,8 @@ specified) run these steps:
    <li><p>If one of <var>notification</var>'s <a for=notification>actions</a> was activated by the
    user, then set <var>action</var> to that <a for=notification>action</a>'s <a for=action>name</a>.
 
-   <li><p>Let <var>callback</var> be an algorithm that when invoked with a <var>global</var>,
-   <a lt="fire a service worker notification event named e">fires a service worker notification event</a>
-   named <code>notificationclick</code> given <var>notification</var> and <var>action</var> on
-   <var>global</var>.
-
-   <li><p>Then run <a>Handle Functional Event</a> with <var>notification</var>'s
-   <a for=notification>service worker registration</a> and <var>callback</var>.
+   <li><a>Fire a service worker notification event</a> named "<code>notificationclick</code>" given
+   <var>notification</var> and <var>action</var>.
   </ol>
 
  <li>
@@ -571,18 +566,9 @@ must be run.
 <p>To <dfn>handle close events</dfn> given a <var>notification</var>, run these steps:
 
 <ol>
- <li>
-  <p>If <var>notification</var> is a <a>persistent notification</a> and
-  <var>notification</var> was closed by the user, then:
-
-  <ol>
-   <li><p>Let <var>callback</var> be an algorithm that when invoked with a <var>global</var>,
-   <a lt="fire a service worker notification event named e">fires a service worker notification event</a>
-   named <code>notificationclose</code> given <var>notification</var> on <var>global</var>.
-
-   <li><p>Then run <a>Handle Functional Event</a> with <var>notification</var>'s
-   <a for=notification>service worker registration</a> and <var>callback</var>.
-  </ol>
+ <li><p>If <var>notification</var> is a <a>persistent notification</a> and <var>notification</var>
+ was closed by the user, then <a>Fire a service worker notification event</a> named
+ "<code>notificationclose</code>" given <var>notification</var>.
 
  <li><p>If <var>notification</var> is a <a>non-persistent notification</a>, then <a>queue a task</a>
  to <a>fire an event</a> named <code>close</code> on the {{Notification}} object representing
@@ -1083,13 +1069,18 @@ the same underlying <a>notification</a> of {{Notification}} objects already in e
 
 <hr>
 
-<p>To <dfn>fire a service worker notification event named <var>e</var></dfn>
-given <var>notification</var> and <var>action</var>,
-<a>fire an event</a> named <var>e</var>, using {{NotificationEvent}}, with the
-{{NotificationEvent/notification}} attribute initialized to a new
-{{Notification}} object representing <var>notification</var> and the
-{{NotificationEvent/action}} attribute initialized to <var>action</var>.
-<!-- XXX need to define at what the event is fired -->
+<p>To <dfn>fire a service worker notification event</dfn> named <var>name</var> given
+<var>notification</var> (a <a>notification</a>), and an optional <var>action</var> (a DOMString,
+defaulting to the empty string), <a>Fire Functional Event</a> <var>name</var> using
+{{NotificationEvent}} on <var>notification</var>'s
+<a for=notification>service worker registration</a> with the following properties:
+
+<dl>
+ <dt>{{NotificationEvent/notification}}
+ <dd>A new {{Notification}} object representing <var>notification</var>.
+ <dt>{{NotificationEvent/action}}
+ <dd><var>action</var>
+</dl>
 
 <p>The {{NotificationEvent/notification}} attribute's getter must return the
 value it was initialized to.
@@ -1165,8 +1156,6 @@ by John Gregg (<a href=https://www.google.com/>Google</a>,
 urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: webappapis.html; type: dfn
         text: entry settings object
-urlPrefix: https://w3c.github.io/ServiceWorker/; type: dfn
-    text: handle functional event; url:handle-functional-event-algorithm
 urlPrefix: https://w3c.github.io/vibration/
     urlPrefix: #dfn-; type: dfn
         text: perform vibration


### PR DESCRIPTION
I've simplified event firing as part of https://github.com/w3c/ServiceWorker/pull/1199.

Don't merge this until https://github.com/w3c/ServiceWorker/pull/1199 merges, but you can review now.