### PR TITLE
Fixes #93 - Restrict requesting permission to secure contexts

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -317,6 +317,14 @@ meaning "<code>granted</code>". In that case
 "<code>granted</code>" is simply returned as there would be no reason
 for the application to ask for <a>permission</a>.
 
+<h3 id="permissions-integration">Permissions integration</h3>
+
+<p>The Notifications API is a <a>powerful feature</a> which is identified by the string
+"notifications" and has its <a for="powerful feature">allowed in non-secure contexts</a> flag set.
+[[!Permissions]]
+
+<p class="note">This specification's "<code>default</code>" <a>permission</a>
+state maps to the [=permission/prompt=] permission state in the Permissions API.
 
 <h3 id=direction>Direction</h3>
 
@@ -729,8 +737,20 @@ constructor steps are:
 return the <a>permission</a> for the <a>current settings object</a>'s
 <a for="environment settings object">origin</a>.
 
-<p class=note>If you edit standards please refrain from copying the above. Synchronous
-permissions are like synchronous IO, a bad idea.
+<div class=note>
+ <p>If you edit standards please refrain from copying the above. Synchronous permissions are like
+ synchronous IO, a bad idea.
+
+ <p>Developers are encouraged to use the Permissions {{Permissions/query()}} method
+ instead. [[Permissions]]
+
+ <pre class="example" id="permissions-query-example">
+    const permission = await navigator.permissions.query({name: "notifications"});
+    if (permission.state === "granted") {
+       // We have permission to use the API…
+    }
+ </pre>
+</div>
 
 <p>The static
 <dfn method for=Notification><code>requestPermission(<var>deprecatedCallback</var>)</code></dfn>
@@ -739,10 +759,12 @@ method steps are:
 <ol>
  <li><p>Let <var>global</var> be the <a>current global object</a>.
 
- <li><p>Let <var>origin</var> be the <a>current settings object</a>'s
- <a for="environment settings object">origin</a>.
- <!-- Arguably this should snapshot origin somehow so that changes to it do not impact the
-      in parallel part. -->
+ <li><p>Let <var>permissionDescriptor</var> be the {{PermissionDescriptor}} with
+ {{PermissionDescriptor/name}} set to "<code>notifications</code>".
+
+ <li><p>Let <var>permissionStatus</var> be the result of
+ <a lt="create a PermissionStatus">creating a `PermissionStatus`</a> for
+ <var>permissionDescriptor</var>.
 
  <li><p>Let <var>promise</var> be <a for=/>a new promise</a> in <a>this</a>'s <a>relevant Realm</a>.
 
@@ -750,24 +772,25 @@ method steps are:
   <p>Run these steps <a>in parallel</a>:
 
   <ol>
-   <li><p>Let <var>permission</var> be <a>permission</a> for <var>origin</var>.
+   <li><p>Run the <a for="powerful feature">permission query algorithm</a> with
+   <var>permissionDescriptor</var> and <var>permissionStatus</var>.
 
-   <li><p>If <var>permission</var> is "<code>default</code>", then ask the user whether showing
-   notifications for <var>origin</var> is acceptable. If it is, then set <var>permission</var> to
-   "<code>granted</code>"; otherwise "<code>denied</code>".
+   <li><p>Let <var>permissionState</var> be <var>permissionStatus</var>'s
+   {{PermissionStatus/state}}.
+
+   <li><p>If <var>permissionState</var> is {{PermissionState/"prompt"}}, then set
+   <var>permissionState</var> to "<code>default</code>".
 
    <li>
     <p><a>Queue a global task</a> on the <a>DOM manipulation task source</a> given <var>global</var>
     to run these steps:
 
     <ol>
-     <li><p>Set <a>permission</a> for <var>origin</var> to <var>permission</var>.
-
      <li><p>If <var>deprecatedCallback</var> is given, then <a for=/>invoke</a>
-     <var>deprecatedCallback</var> with « <var>permission</var> ». If this throws an exception, then
-     <a>report the exception</a>.
+     <var>deprecatedCallback</var> with « <var>permissionState</var> ». If this throws an
+     exception, then <a>report the exception</a>.
 
-     <li><p><a for=/>Resolve</a> <var>promise</var> with <var>permission</var>.
+     <li><p><a for=/>Resolve</a> <var>promise</var> with <var>permissionState</var>.
     </ol>
   </ol>
 
@@ -1186,6 +1209,7 @@ Michael Cooper,
 Michael Henretty,
 Michael™ Smith,
 Michael van Ouwerkerk,
+Mike Taylor,
 Nicolás Satragno,
 Olli Pettay,
 Peter Beverloo,

--- a/notifications.bs
+++ b/notifications.bs
@@ -325,6 +325,7 @@ for the application to ask for <a>permission</a>.
 <p class="note">This specification's "<code>default</code>" <a>permission</a>
 state maps to the [=permission/prompt=] permission state in the Permissions API.
 
+
 <h3 id=direction>Direction</h3>
 
 <p>This section is written in terms equivalent to those used in the Rendering

--- a/notifications.bs
+++ b/notifications.bs
@@ -320,8 +320,7 @@ for the application to ask for <a>permission</a>.
 <h3 id="permissions-integration">Permissions integration</h3>
 
 <p>The Notifications API is a <a>powerful feature</a> which is identified by the string
-"notifications" and has its <a for="powerful feature">allowed in non-secure contexts</a> flag set.
-[[!Permissions]]
+"notifications". [[!Permissions]]
 
 <p class="note">This specification's "<code>default</code>" <a>permission</a>
 state maps to the [=permission/prompt=] permission state in the Permissions API.
@@ -734,8 +733,32 @@ constructor steps are:
 <h3 id=static-members>Static members</h3>
 
 <p>The static <dfn attribute for=Notification><code>permission</code></dfn> getter steps are to
-return the <a>permission</a> for the <a>current settings object</a>'s
-<a for="environment settings object">origin</a>.
+return the result of <a>querying the notifications permission state</a>.
+
+<p>To <dfn>query the notifications permission state</dfn>, run these steps:
+
+<ol>
+ <li><p>Let <var>settings</var> be the <a>current settings object</a>.
+
+ <li><p>If <var>settings</var> is not a <a>secure context</a>, return "<code>denied</code>".
+
+ <li><p>Otherwise, let <var>permissionDescriptor</var> be the {{PermissionDescriptor}} with
+ {{PermissionDescriptor/name}} set to "<code>notifications</code>".
+
+ <li><p>Let <var>permissionStatus</var> be the result of
+ <a lt="create a PermissionStatus">creating a `PermissionStatus`</a> for
+ <var>permissionDescriptor</var>.
+
+ <li><p>Run the <a for="powerful feature">permission query algorithm</a> with
+ <var>permissionDescriptor</var> and <var>permissionStatus</var>.
+
+ <li><p>Let <var>permissionState</var> be <var>permissionStatus</var>'s {{PermissionStatus/state}}.
+
+ <li><p>If <var>permissionState</var> is {{PermissionState/"prompt"}}, then set
+ <var>permissionState</var> to "<code>default</code>".
+
+ <li><p>Return <var>permissionState</var>.
+</ol>
 
 <div class=note>
  <p>If you edit standards please refrain from copying the above. Synchronous permissions are like
@@ -759,42 +782,28 @@ method steps are:
 <ol>
  <li><p>Let <var>global</var> be the <a>current global object</a>.
 
- <li><p>Let <var>permissionDescriptor</var> be the {{PermissionDescriptor}} with
- {{PermissionDescriptor/name}} set to "<code>notifications</code>".
-
- <li><p>Let <var>permissionStatus</var> be the result of
- <a lt="create a PermissionStatus">creating a `PermissionStatus`</a> for
- <var>permissionDescriptor</var>.
-
  <li><p>Let <var>promise</var> be <a for=/>a new promise</a> in <a>this</a>'s <a>relevant Realm</a>.
 
  <li>
   <p>Run these steps <a>in parallel</a>:
 
   <ol>
-   <li><p>Run the <a for="powerful feature">permission query algorithm</a> with
-   <var>permissionDescriptor</var> and <var>permissionStatus</var>.
+   <li><p>Let <var>permissionState</var> be the result of
+   <a>querying the notifications permission state</a>.
 
-   <li><p>Let <var>permissionState</var> be <var>permissionStatus</var>'s
-   {{PermissionStatus/state}}.
+   <li><p><a>Queue a global task</a> on the <a>DOM manipulation task source</a> given
+   <var>global</var> to run these steps:
 
-   <li><p>If <var>permissionState</var> is {{PermissionState/"prompt"}}, then set
-   <var>permissionState</var> to "<code>default</code>".
+   <ol>
+    <li><p>If <var>deprecatedCallback</var> is given, then <a for=/>invoke</a>
+    <var>deprecatedCallback</var> with « <var>permissionState</var> ». If this throws an
+    exception, then <a>report the exception</a>.
 
-   <li>
-    <p><a>Queue a global task</a> on the <a>DOM manipulation task source</a> given <var>global</var>
-    to run these steps:
-
-    <ol>
-     <li><p>If <var>deprecatedCallback</var> is given, then <a for=/>invoke</a>
-     <var>deprecatedCallback</var> with « <var>permissionState</var> ». If this throws an
-     exception, then <a>report the exception</a>.
-
-     <li><p><a for=/>Resolve</a> <var>promise</var> with <var>permissionState</var>.
-    </ol>
+    <li><p><a for=/>Resolve</a> <var>promise</var> with <var>permissionState</var>.
+   </ol>
   </ol>
 
- <li><p>Return <var>promise</var>.
+  <li><p>Return <var>promise</var>.
 </ol>
 
 <p class="warning">Notifications are the one instance thus far where asking the


### PR DESCRIPTION
- [x] At least two implementers are interested (and none opposed):
     * Chrome, Firefox, and Safari behave this way today.
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/31495 landed.
- [x] [Implementation bugs] N/A


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/175.html" title="Last updated on Nov 19, 2021, 1:23 AM UTC (b49c447)">Preview</a> | <a href="https://whatpr.org/notifications/175/df1b6db...b49c447.html" title="Last updated on Nov 19, 2021, 1:23 AM UTC (b49c447)">Diff</a>