### PR TITLE
Review Draft Publication: January 2022

### DIFF
--- a/review-drafts/2022-01.bs
+++ b/review-drafts/2022-01.bs
@@ -1,5 +1,6 @@
 <pre class=metadata>
 Group: WHATWG
+Date: 2022-01-17
 H1: Notifications API
 Shortname: notifications
 Text Macro: TWITTER notifyapi


### PR DESCRIPTION
The [January 2022 Review Draft](https://notifications.spec.whatwg.org/review-drafts/2022-01/) for this Workstream will be published shortly after merging this pull request.

Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/178.html" title="Last updated on Jan 17, 2022, 5:50 PM UTC (ea580c5)">Preview</a> | <a href="https://whatpr.org/notifications/178/01e8216...ea580c5.html" title="Last updated on Jan 17, 2022, 5:50 PM UTC (ea580c5)">Diff</a>