### PR TITLE
Meta: remove HTML anchor

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -9,11 +9,7 @@ Translation: ja https://triple-underscore.github.io/notifications-ja.html
 Translation: zh-cn https://w3c-html-ig-zh.github.io/notifications/whatwg/
 </pre>
 
-<!-- Remove the HTML entry once https://github.com/whatwg/html/pull/6360 is resolved. -->
 <pre class=anchors>
-urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html#; spec: html;
-    type: dfn;
-        text: DOM manipulation task source; url: dom-manipulation-task-source
 urlPrefix: https://w3c.github.io/vibration/
     urlPrefix: #dfn-; type: dfn
         text: perform vibration


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/188.html" title="Last updated on Jan 16, 2023, 7:45 AM UTC (945a9de)">Preview</a> | <a href="https://whatpr.org/notifications/188/ed277b3...945a9de.html" title="Last updated on Jan 16, 2023, 7:45 AM UTC (945a9de)">Diff</a>