### PR TITLE
Editorial: Remove a use of "epoch-relative timestamp", in favor of newer terminology.

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -18,9 +18,6 @@ urlPrefix: https://w3c.github.io/vibration/
         text: VibratePattern; url: vibratepattern
 urlPrefix: https://tc39.github.io/ecma262/#sec-object.; type: dfn
     text: freeze
-urlPrefix: https://w3c.github.io/hr-time/#
-    type: typedef; text: EpochTimeStamp; urlPrefix: dom-
-    type: dfn; text: epoch-relative timestamp; urlPrefix: dfn-
 </pre>
 
 
@@ -228,7 +225,9 @@ string <var>title</var>, {{NotificationOptions}} <a for=/>dictionary</a> <var>op
 
  <li><p>If <var>options</var>["{{NotificationOptions/timestamp}}"] <a for=map>exists</a>, then set
  <var>notification</var>'s <a for=notification>timestamp</a> to the value. Otherwise, set
- <var>notification</var>'s <a for=notification>timestamp</a> to the <a>epoch-relative timestamp</a>.
+ <var>notification</var>'s <a for=notification>timestamp</a> to the number of milliseconds from the
+ <a>Unix epoch</a> to <var>settings</var>' <a for="environment settings object">current wall
+ time</a>, rounded to the nearest integer.
 
  <li><p>Set <var>notification</var>'s <a for=notification>renotify preference</a> to
  <var>options</var>["{{NotificationOptions/renotify}}"].

--- a/notifications.bs
+++ b/notifications.bs
@@ -226,8 +226,8 @@ string <var>title</var>, {{NotificationOptions}} <a for=/>dictionary</a> <var>op
  <li><p>If <var>options</var>["{{NotificationOptions/timestamp}}"] <a for=map>exists</a>, then set
  <var>notification</var>'s <a for=notification>timestamp</a> to the value. Otherwise, set
  <var>notification</var>'s <a for=notification>timestamp</a> to the number of milliseconds from the
- <a>Unix epoch</a> to <var>settings</var>' <a for="environment settings object">current wall
- time</a>, rounded to the nearest integer.
+ <a>Unix epoch</a> to <var>settings</var>'s
+ <a for="environment settings object">current wall time</a>, rounded to the nearest integer.
 
  <li><p>Set <var>notification</var>'s <a for=notification>renotify preference</a> to
  <var>options</var>["{{NotificationOptions/renotify}}"].


### PR DESCRIPTION
According to https://dontcallmedom.github.io/webdex/e.html#epoch-relative%20timestamp%40%40hr-time%25%25dfn, this is the last use.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/192.html" title="Last updated on Mar 22, 2023, 8:58 AM UTC (3525a7d)">Preview</a> | <a href="https://whatpr.org/notifications/192/14602f0...3525a7d.html" title="Last updated on Mar 22, 2023, 8:58 AM UTC (3525a7d)">Diff</a>