### PR TITLE
Default silent to platform convention

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -84,7 +84,8 @@ an existing notification.
 
 <p>A <a>notification</a> has an associated
 <dfn for=notification id=silent-preference-flag>silent preference</dfn> boolean, which is initially
-false. When true, indicates that no sounds or vibrations should be made.
+null. When true, indicates that no sounds or vibrations should be made. When null, indicates that
+producing sounds or vibrations should be left to platform conventions.
 
 <p>A <a>notification</a> has an associated
 <dfn for=notification id=require-interaction-preference-flag>require interaction preference</dfn>
@@ -616,7 +617,7 @@ interface Notification : EventTarget {
   [SameObject] readonly attribute FrozenArray&lt;unsigned long> vibrate;
   readonly attribute EpochTimeStamp timestamp;
   readonly attribute boolean renotify;
-  readonly attribute boolean silent;
+  readonly attribute boolean? silent;
   readonly attribute boolean requireInteraction;
   [SameObject] readonly attribute any data;
   [SameObject] readonly attribute FrozenArray&lt;NotificationAction> actions;
@@ -635,7 +636,7 @@ dictionary NotificationOptions {
   VibratePattern vibrate;
   EpochTimeStamp timestamp;
   boolean renotify = false;
-  boolean silent = false;
+  boolean? silent = null;
   boolean requireInteraction = false;
   any data = null;
   sequence&lt;NotificationAction> actions = [];

--- a/notifications.bs
+++ b/notifications.bs
@@ -83,7 +83,7 @@ initially false. When true, indicates that the end user should be alerted after 
 an existing notification.
 
 <p>A <a>notification</a> has an associated
-<dfn for=notification id=silent-preference-flag>silent preference</dfn> nullable boolean, which is
+<dfn for=notification id=silent-preference-flag>silent preference</dfn> boolean or null, which is
 initially null. When true, indicates that no sounds or vibrations should be made. When null,
 indicates that producing sounds or vibrations should be left to platform conventions.
 

--- a/notifications.bs
+++ b/notifications.bs
@@ -83,9 +83,9 @@ initially false. When true, indicates that the end user should be alerted after 
 an existing notification.
 
 <p>A <a>notification</a> has an associated
-<dfn for=notification id=silent-preference-flag>silent preference</dfn> boolean, which is initially
-null. When true, indicates that no sounds or vibrations should be made. When null, indicates that
-producing sounds or vibrations should be left to platform conventions.
+<dfn for=notification id=silent-preference-flag>silent preference</dfn> nullable boolean, which is
+initially null. When true, indicates that no sounds or vibrations should be made. When null,
+indicates that producing sounds or vibrations should be left to platform conventions.
 
 <p>A <a>notification</a> has an associated
 <dfn for=notification id=require-interaction-preference-flag>require interaction preference</dfn>


### PR DESCRIPTION
<!--
Thank you for contributing to the Notifications API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

Closes #193 

- [x] At least two implementers are interested (and none opposed):
   * WebKit
   * Chromium per https://github.com/whatwg/notifications/pull/194#issuecomment-1551191216
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/WebKit/WebKit/pull/13912
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1446893
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1834005
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=256828
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/26812

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/194.html" title="Last updated on May 19, 2023, 12:57 PM UTC (a6b4f0c)">Preview</a> | <a href="https://whatpr.org/notifications/194/8b4002d...a6b4f0c.html" title="Last updated on May 19, 2023, 12:57 PM UTC (a6b4f0c)">Diff</a>