### PR TITLE
Add [SecureContext] tags to the interfaces

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -592,7 +592,7 @@ must be run.
 <h2 id=api>API</h2>
 
 <pre class=idl>
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), SecureContext]
 interface Notification : EventTarget {
   constructor(DOMString title, optional NotificationOptions options = {});
 
@@ -999,12 +999,13 @@ dictionary GetNotificationOptions {
   DOMString tag = "";
 };
 
+[SecureContext]
 partial interface ServiceWorkerRegistration {
   Promise&lt;undefined> showNotification(DOMString title, optional NotificationOptions options = {});
   Promise&lt;sequence&lt;Notification>> getNotifications(optional GetNotificationOptions filter = {});
 };
 
-[Exposed=ServiceWorker]
+[Exposed=ServiceWorker, SecureContext]
 interface NotificationEvent : ExtendableEvent {
   constructor(DOMString type, NotificationEventInit eventInitDict);
 
@@ -1017,6 +1018,7 @@ dictionary NotificationEventInit : ExtendableEventInit {
   DOMString action = "";
 };
 
+[SecureContext]
 partial interface ServiceWorkerGlobalScope {
   attribute EventHandler onnotificationclick;
   attribute EventHandler onnotificationclose;


### PR DESCRIPTION
- addresses https://github.com/w3c/webref/issues/1142#issuecomment-1924200755

`w3c/webref` repo automatically extracts syntaxes from these spec docs. At the moment some syntax sections are missing the `[SecureContext]` tags so it is [missing from extracted data in webref as well](https://github.com/w3c/webref/blob/1ebc07b4638f130623f054e556da62fd6a045e01/ed/idl/notifications.idl#L6).

The feature has been [marked available in secure context in MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Notification). 

The PR adds the tags to the remaining interfaces.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/202.html" title="Last updated on Feb 5, 2024, 2:17 PM UTC (26cb383)">Preview</a> | <a href="https://whatpr.org/notifications/202/fab345b...26cb383.html" title="Last updated on Feb 5, 2024, 2:17 PM UTC (26cb383)">Diff</a>