### PR TITLE
Editorial: Update use of WebIDL "invoke a callback function"

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -762,8 +762,7 @@ method steps are:
 
     <ol>
      <li><p>If <var>deprecatedCallback</var> is given, then <a for=/>invoke</a>
-     <var>deprecatedCallback</var> with « <var>permissionState</var> ». If this throws an
-     exception, then <a>report the exception</a>.
+     <var>deprecatedCallback</var> with « <var>permissionState</var> » and "<code>report</code>".
 
      <li><p><a for=/>Resolve</a> <var>promise</var> with <var>permissionState</var>.
     </ol>


### PR DESCRIPTION
The single use no longer needs to report the exception itself.

Part of whatwg/webidl#1425.

- [x] At least two implementers are interested (and none opposed): n/a (no normative change)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at: n/a (no normative change)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed: n/a (no normative change)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: n/a (no normative change)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/whatwg-notifications/216.html" title="Last updated on Aug 2, 2024, 6:18 PM UTC (d83c188)">Preview</a> | <a href="https://whatpr.org/notifications/216/221c867...d83c188.html" title="Last updated on Aug 2, 2024, 6:18 PM UTC (d83c188)">Diff</a>