### PR TITLE
Meta: export notification's service worker registration

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -45,7 +45,7 @@ IDL, Service Workers, URL, and Vibration API Standards.
 representation of something that happened, such as the delivery of a message.
 
 <p>A <a for=/>notification</a> has an associated
-<dfn for=notification id=service-worker-registration>service worker registration</dfn> (null
+<dfn export for=notification id=service-worker-registration>service worker registration</dfn> (null
 or a <a for=/>service worker registration</a>). It is initially null.
 
 <p>A <a for=/>notification</a> has an associated <dfn for=notification id=concept-title>title</dfn> (a string).


### PR DESCRIPTION
9a8242eba3cb369f5a0f102d4acb3c011493fb19 made this a responsible of the caller, but with Declarative Web Push the caller is in a different specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/225.html" title="Last updated on Nov 6, 2024, 2:15 PM UTC (307ffa4)">Preview</a> | <a href="https://whatpr.org/notifications/225/7b0aee1...307ffa4.html" title="Last updated on Nov 6, 2024, 2:15 PM UTC (307ffa4)">Diff</a>