### PR TITLE
Editorial: rename action to notification action and export it

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -126,20 +126,21 @@ is not otherwise accessible to the end user, especially since notification platf
 support these features might ignore them.
 
 <p>A <a for=/>notification</a> has associated <dfn for=notification id=actions>actions</dfn> (a
-<a for=/>list</a> of zero or more <a for=/>actions</a>). An <dfn>action</dfn> represents a choice
-for an end user. Each <a for=/>action</a> has an associated:
+<a for=/>list</a> of zero or more <a for=/>actions</a>). A
+<dfn export id=action>notification action</dfn> represents a choice for an end user. Each
+<a for=/>notification action</a> has an associated:
 
 <dl>
- <dt><dfn for=action id=action-name>name</dfn>
+ <dt><dfn for="notification action" id=action-name>name</dfn>
  <dd>A string.
 
- <dt><dfn for=action id=action-title>title</dfn>
+ <dt><dfn for="notification action" id=action-title>title</dfn>
  <dd>A string.
 
- <dt><dfn for=action>icon URL</dfn>
+ <dt><dfn for="notification action" id=action-icon-url>icon URL</dfn>
  <dd>Null or a <a for=/>URL</a>. It is initially null.
 
- <dt><dfn for=action>icon resource</dfn>
+ <dt><dfn for="notification action" id=action-icon-resource>icon resource</dfn>
  <dd>Null or a resource. It is initially null.
 </dl>
 
@@ -151,11 +152,11 @@ or more, within the constraints of the notification platform.
 that any action an end user can invoke from a notification is also available within the web
 application.
 
-<p class="note no-backref">Some platforms might modify an <a for=action>icon resource</a> to better
-match the platform's visual style before displaying it to the end user, for example by rounding the
-corners or painting it in a specific color. Developers are encouraged to use an icon that handles
-such cases gracefully and does not lose important information through, e.g., loss of color or
-clipped corners.
+<p class="note no-backref">Some platforms might modify an
+<a for="notification action">icon resource</a> to better match the platform's visual style before
+displaying it to the end user, for example by rounding the corners or painting it in a specific
+color. Developers are encouraged to use an icon that handles such cases gracefully and does not lose
+important information through, e.g., loss of color or clipped corners.
 
 <p>A <dfn>non-persistent notification</dfn> is a <a for=/>notification</a> whose
 <a for=notification>service worker registration</a> is null.
@@ -261,18 +262,18 @@ clipped corners.
   <a>maximum number of actions</a> supported (skip any excess entries):
 
   <ol>
-   <li><p>Let <var>action</var> be a new <a for=/>action</a>.
+   <li><p>Let <var>action</var> be a new <a for=/>notification action</a>.
 
-   <li><p>Set <var>action</var>'s <a for=action>name</a> to
+   <li><p>Set <var>action</var>'s <a for="notification action">name</a> to
    <var>entry</var>["{{NotificationAction/action}}"].
 
-   <li><p>Set <var>action</var>'s <a for=action>title</a> to
+   <li><p>Set <var>action</var>'s <a for="notification action">title</a> to
    <var>entry</var>["{{NotificationAction/title}}"].
 
    <li><p>If <var>entry</var>["{{NotificationAction/icon}}"] <a for=map>exists</a>, then
    <a lt="URL parser">parse</a> it using <var>baseURL</var>, and if that does not return failure,
-   set <var>action</var>'s <a for=action>icon URL</a> to the return value. (Otherwise
-   <var>action</var>'s <a for=action>icon URL</a> remains null.)
+   set <var>action</var>'s <a for="notification action">icon URL</a> to the return value. (Otherwise
+   <var>action</var>'s <a for="notification action">icon URL</a> remains null.)
 
    <li><p>Append <var>action</var> to <var>notification</var>'s <a for=notification>actions</a>.
   </ol>
@@ -334,13 +335,13 @@ section of HTML. [[!HTML]]
 
 <p>User agents are expected to honor the Unicode semantics of the text of a
 <a for=/>notification</a>'s <a for=notification>title</a>, <a for=notification>body</a>, and the
-<a for=action>title</a> of each of its <a for=notification>actions</a>. Each is expected
-to be treated as an independent set of one or more bidirectional algorithm
+<a for="notification action">title</a> of each of its <a for=notification>actions</a>. Each is
+expected to be treated as an independent set of one or more bidirectional algorithm
 paragraphs when displayed, as defined by the bidirectional algorithm's rules P1,
 P2, and P3, including, for instance, supporting the paragraph-breaking behavior
 of U+000A LINE FEED (LF) characters. For each paragraph of the
 <a for=notification>title</a>, <a for=notification>body</a> and the
-<a for=action>title</a> of each of the <a for=notification>actions</a>, the
+<a for="notification action">title</a> of each of the <a for=notification>actions</a>, the
 <a for=/>notification</a>'s
 <a for=notification>direction</a> provides the higher-level override of
 rules P2 and P3 if it has a value other than "<code>auto</code>". [[!BIDI]]
@@ -439,8 +440,9 @@ interpreted as a language tag. Validity or well-formedness are not enforced. [[!
 
  <li>
   <p>If the notification platform supports actions and action icons, then for each <var>action</var>
-  in <var>notification</var>'s <a for=notification>actions</a>: if <a for=action>icon URL</a> is
-  non-null, <a for=/>fetch</a> <var>action</var>'s <a for=action>icon URL</a>.
+  in <var>notification</var>'s <a for=notification>actions</a>: if
+  <a for="notification action">icon URL</a> is non-null, <a for=/>fetch</a> <var>action</var>'s
+  <a for="notification action">icon URL</a>.
 
   <p class=note>The intent is to fetch this resource similar to an
   <a href="https://html.spec.whatwg.org/multipage/images.html#update-the-image-data"><code>&lt;img&gt;</code></a>,
@@ -455,8 +457,8 @@ interpreted as a language tag. Validity or well-formedness are not enforced. [[!
    "<code>default</code>", then attempt to decode the resource as image.
 
    <li><p>If the image format is supported, then set <var>action</var>'s
-   <a for=action>icon resource</a> to the decoded resource. (Otherwise <var>action</var>'s
-   <a for=action>icon resource</a> remains null.)
+   <a for="notification action">icon resource</a> to the decoded resource. (Otherwise
+   <var>action</var>'s <a for="notification action">icon resource</a> remains null.)
   </ol>
  </li>
 </ol>
@@ -476,8 +478,8 @@ interpreted as a language tag. Validity or well-formedness are not enforced. [[!
  <li><p>Wait for any <a for=/ lt=fetch>fetches</a> to complete and <var>notification</var>'s
  <a for=notification>image resource</a>, <a for=notification>icon resource</a>, and
  <a for=notification>badge resource</a> to be set (if any), as well as the
- <a for=action>icon resources</a> for the <var>notification</var>'s <a for=notification>actions</a>
- (if any).
+ <a for="notification action">icon resources</a> for the <var>notification</var>'s
+ <a for=notification>actions</a> (if any).
 
  <li><p>Let <var>shown</var> be false.
 
@@ -546,7 +548,8 @@ platform supports activation, the user agent must (unless otherwise specified) r
    <li><p>Let <var>action</var> be the empty string.
 
    <li><p>If one of <var>notification</var>'s <a for=notification>actions</a> was activated by the
-   user, then set <var>action</var> to that <a for=/>action</a>'s <a for=action>name</a>.
+   user, then set <var>action</var> to that <a for=/>notification action</a>'s
+   <a for="notification action">name</a>.
 
    <li><a>Fire a service worker notification event</a> named "<code>notificationclick</code>" given
    <var>notification</var> and <var>action</var>.
@@ -917,14 +920,14 @@ then return null.
    <li><p>Let <var>action</var> be a new {{NotificationAction}}.
 
    <li><p>Set <var>action</var>["{{NotificationAction/action}}"] to <var>entry</var>'s
-   <a for=action>name</a>.
+   <a for="notification action">name</a>.
 
    <li><p>Set <var>action</var>["{{NotificationAction/title}}"] to <var>entry</var>'s
-   <a for=action>title</a>.
+   <a for="notification action">title</a>.
 
-   <li><p>If <var>entry</var>'s <a for=action>icon URL</a> is non-null, then set
+   <li><p>If <var>entry</var>'s <a for="notification action">icon URL</a> is non-null, then set
    <var>action</var>["{{NotificationAction/icon}}"] to <var>entry</var>'s
-   <a for=action>icon URL</a>, <a lt="URL serializer">serialized</a>.
+   <a for="notification action">icon URL</a>, <a lt="URL serializer">serialized</a>.
 
    <!-- XXX IDL dictionaries are usually returned by value, so don't need to be
         immutable. But FrozenArray reifies the dictionaries to mutable JS
@@ -960,10 +963,11 @@ not.onclick = function() { displaySong(this); };</pre>
 <p><a lt="persistent notification">Persistent notifications</a> fire
 <code>notificationclick</code> events on the {{ServiceWorkerGlobalScope}}.
 
-<p>Here a service worker shows a notification with a single "Archive" <a for=/>action</a>, allowing
-end users to perform this common task from the notification without having to open the website (for
-example, the notification platform might show a button on the notification). The end user can also
-activate the main body of the notification to open their inbox.
+<p>Here a service worker shows a notification with a single "Archive"
+<a for=/>notification action</a>, allowing end users to perform this common task from the
+notification without having to open the website (for example, the notification platform might show a
+button on the notification). The end user can also activate the main body of the notification to
+open their inbox.
 
 <pre class=example id=example-50e7c86c>
 self.registration.showNotification("New mail from Alice", {

--- a/notifications.bs
+++ b/notifications.bs
@@ -125,8 +125,8 @@ initially « ».
 is not otherwise accessible to the end user, especially since notification platforms that do not
 support these features might ignore them.
 
-<p>A <a for=/>notification</a> has associated <dfn for=notification id=actions>actions</dfn> (a
-<a for=/>list</a> of zero or more <a for=/>notification actions</a>). A
+<p>A <a for=/>notification</a> has associated <dfn export for=notification id=actions>actions</dfn>
+(a <a for=/>list</a> of zero or more <a for=/>notification actions</a>). A
 <dfn export id=action>notification action</dfn> represents a choice for an end user. Each
 <a for=/>notification action</a> has an associated:
 

--- a/notifications.bs
+++ b/notifications.bs
@@ -126,7 +126,7 @@ is not otherwise accessible to the end user, especially since notification platf
 support these features might ignore them.
 
 <p>A <a for=/>notification</a> has associated <dfn for=notification id=actions>actions</dfn> (a
-<a for=/>list</a> of zero or more <a for=/>actions</a>). A
+<a for=/>list</a> of zero or more <a for=/>notification actions</a>). A
 <dfn export id=action>notification action</dfn> represents a choice for an end user. Each
 <a for=/>notification action</a> has an associated:
 


### PR DESCRIPTION
This is needed for Declarative Web Push.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/226.html" title="Last updated on Nov 7, 2024, 2:50 PM UTC (ecf4faa)">Preview</a> | <a href="https://whatpr.org/notifications/226/c032675...ecf4faa.html" title="Last updated on Nov 7, 2024, 2:50 PM UTC (ecf4faa)">Diff</a>