### PR TITLE
Editorial: add "has showNotification() been successfully invoked"

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -1064,6 +1064,12 @@ partial interface ServiceWorkerGlobalScope {
 };
 </pre>
 
+<p>A <a for=/>service worker registration</a> has an associated
+<dfn export for="service worker registration">has <code>showNotification()</code> been successfully invoked</dfn>
+(a <a for=/>boolean</a>), which is initially false.
+
+<p class=note>This is infrastructure for the <cite>Push API</cite> standard. [[PUSH-API]]
+
 <div algorithm>
 <p>The
 <dfn method for=ServiceWorkerRegistration><code>showNotification(<var>title</var>, <var>options</var>)</code></dfn>
@@ -1097,6 +1103,10 @@ method steps are:
    <var>promise</var> with a {{TypeError}}, and abort these steps.
 
    <li><p>Run the <a for=/>notification show steps</a> for <var>notification</var>.
+
+   <li><p>Set <var>notification</var>'s <a for=notification>service worker registration</a>'s
+   <a for="service worker registration">has <code>showNotification()</code> been successfully invoked</a>
+   to true.
 
    <li><p><a>Queue a global task</a> on the <a>DOM manipulation task source</a> given
    <var>global</var> to <a for=/>resolve</a> <var>promise</var> with undefined.


### PR DESCRIPTION
This is a concept needed for Declarative Web Push: see https://github.com/w3c/push-api/issues/360 for context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/notifications/227.html" title="Last updated on Dec 5, 2024, 1:55 PM UTC (b1ce818)">Preview</a> | <a href="https://whatpr.org/notifications/227/d7f3e1a...b1ce818.html" title="Last updated on Dec 5, 2024, 1:55 PM UTC (b1ce818)">Diff</a>