### PR TITLE
Remove Notification's vibrate feature

### DIFF
--- a/notifications.bs
+++ b/notifications.bs
@@ -517,8 +517,8 @@ interpreted as a language tag. Validity or well-formedness are not enforced. [[!
   </ol>
 
  <li><p>If <var>shown</var> is false or <var>oldNotification</var> is non-null, and
- <var>notification</var>'s <a for=notification>renotify preference</a> is true, then run the
- <a>alert steps</a> for <var>notification</var>.
+ <var>notification</var>'s <a for=notification>renotify preference</a> is true, then optionally
+ alert the end user in a user-agent-defined manner (e.g., by playing a sound).
 
  <li><p>If <var>notification</var> is a <a>non-persistent notification</a>, then <a>queue a task</a>
  to <a>fire an event</a> named <code>show</code> on the {{Notification}} object representing
@@ -636,12 +636,6 @@ the end user, the <a>close steps</a> for it must be run.
  <var>notification</var>.
 </ol>
 </div>
-
-
-<h3 id=alerting-the-user>Alerting the end user</h3>
-
-<p>The <dfn>alert steps</dfn> for alerting the end user about a given <a for=/>notification</a> are
-to optionally alert the end user in a user-agent-defined manner (e.g., by playing a sound).
 
 
 <h2 id=api>API</h2>

--- a/notifications.bs
+++ b/notifications.bs
@@ -11,12 +11,6 @@ Translation: ko https://ko.htmlspecs.com/notifications/
 </pre>
 
 <pre class=anchors>
-urlPrefix: https://w3c.github.io/vibration/
-    urlPrefix: #dfn-; type: dfn
-        text: perform vibration
-        text: validate and normalize
-    urlPrefix: #idl-def-; type: interface
-        text: VibratePattern; url: vibratepattern
 urlPrefix: https://tc39.github.io/ecma262/
     urlPrefix: #sec-object.; type: dfn
         text: freeze
@@ -29,7 +23,7 @@ urlPrefix: https://tc39.github.io/ecma262/
 <p>This specification depends on the Infra Standard. [[!INFRA]]
 
 <p>Some terms used in this specification are defined in the DOM, Fetch, High Resolution Time, HTML,
-IDL, Service Workers, URL, and Vibration API Standards.
+IDL, Service Workers, and URL Standards.
 [[!DOM]]
 [[!FETCH]]
 [[!HR-TIME]]
@@ -37,7 +31,6 @@ IDL, Service Workers, URL, and Vibration API Standards.
 [[!WEBIDL]]
 [[!SERVICE-WORKERS]]
 [[!URL]]
-[[!VIBRATION]]
 
 
 <h2 id=notifications>Notifications</h2>
@@ -88,8 +81,8 @@ initially false. When true, indicates that the end user should be alerted after 
 
 <p>A <a for=/>notification</a> has an associated
 <dfn for=notification id=silent-preference-flag>silent preference</dfn> (null or a boolean). It is
-initially null. When true, indicates that no sounds or vibrations should be made. When null,
-indicates that producing sounds or vibrations should be left to platform conventions.
+initially null. When true, indicates that no sounds should be made. When null, indicates that
+producing sounds should be left to platform conventions.
 
 <p>A <a for=/>notification</a> has an associated
 <dfn for=notification id=require-interaction-preference-flag>require interaction preference</dfn>
@@ -119,15 +112,10 @@ not enough space to display the <a for=/>notification</a> itself. It <em>may</em
 the <a for=/>notification</a>, but then it should have less visual priority than the
 <a for=notification>image resource</a> and <a for=notification>icon resource</a>.
 
-<p>A <a for=/>notification</a> has an associated
-<dfn for=notification id=vibration-pattern>vibration pattern</dfn> (a <a for=/>list</a>). It is
-initially « ».
-
 <p class=note>Developers are encouraged to not convey information through an
 <a for=notification lt="image resource">image</a>, <a for=notification lt="icon resource">icon</a>,
-<a for=notification lt="badge resource">badge</a>, or <a for=notification>vibration pattern</a> that
-is not otherwise accessible to the end user, especially since notification platforms that do not
-support these features might ignore them.
+or <a for=notification lt="badge resource">badge</a> that is not otherwise accessible to the end
+user, especially since notification platforms that do not support these features might ignore them.
 
 <p>A <a for=/>notification</a> has associated <dfn export for=notification id=actions>actions</dfn>
 (a <a for=/>list</a> of zero or more <a for=/>notification actions</a>). A
@@ -203,10 +191,6 @@ important information through, e.g., loss of color or clipped corners.
 <ol>
  <li><p>Let <var>notification</var> be a new <a for=/>notification</a>.
 
- <li><p>If <var>options</var>["{{NotificationOptions/silent}}"] is true and
- <var>options</var>["{{NotificationOptions/vibrate}}"] <a for=map>exists</a>, then <a>throw</a> a
- {{TypeError}}.
-
  <li><p>If <var>options</var>["{{NotificationOptions/renotify}}"] is true and
  <var>options</var>["{{NotificationOptions/tag}}"] is the empty string, then <a>throw</a> a
  {{TypeError}}.
@@ -249,10 +233,6 @@ important information through, e.g., loss of color or clipped corners.
  <a lt="URL parser">parse</a> it using <var>baseURL</var>, and if that does not return failure, set
  <var>notification</var>'s <a for=notification>badge URL</a> to the return value. (Otherwise
  <var>notification</var>'s <a for=notification>badge URL</a> is not set.)
-
- <li><p>If <var>options</var>["{{NotificationOptions/vibrate}}"] <a for=map>exists</a>, then
- <a>validate and normalize</a> it and set <var>notification</var>'s
- <a for=notification>vibration pattern</a> to the return value.
 
  <li><p>If <var>options</var>["{{NotificationOptions/timestamp}}"] <a for=map>exists</a>, then set
  <var>notification</var>'s <a for=notification>timestamp</a> to the value. Otherwise, set
@@ -660,15 +640,9 @@ the end user, the <a>close steps</a> for it must be run.
 
 <h3 id=alerting-the-user>Alerting the end user</h3>
 
-<div algorithm>
 <p>The <dfn>alert steps</dfn> for alerting the end user about a given <a for=/>notification</a>
-<var>notification</var> are:
-
-<ol>
- <li><p><a>Perform vibration</a> using <var>notification</var>'s
- <a for=notification>vibration pattern</a>, if any.
-</ol>
-</div>
+<var>notification</var> are to optionally alert the end user in a user-agent-defined manner (e.g.,
+by playing a sound).
 
 
 <h2 id=api>API</h2>
@@ -697,7 +671,6 @@ interface Notification : EventTarget {
   readonly attribute USVString image;
   readonly attribute USVString icon;
   readonly attribute USVString badge;
-  [SameObject] readonly attribute FrozenArray&lt;unsigned long> vibrate;
   readonly attribute EpochTimeStamp timestamp;
   readonly attribute boolean renotify;
   readonly attribute boolean? silent;
@@ -717,7 +690,6 @@ dictionary NotificationOptions {
   USVString image;
   USVString icon;
   USVString badge;
-  VibratePattern vibrate;
   EpochTimeStamp timestamp;
   boolean renotify = false;
   boolean? silent = null;
@@ -947,9 +919,6 @@ return the <a>maximum number of actions</a> supported.
  <li><p>Return <a>this</a>'s <a for=/>notification</a>'s <a for=notification>badge URL</a>,
  <a lt="URL serializer">serialized</a>.
 </ol>
-
-<p>The <dfn attribute for=Notification><code>vibrate</code></dfn> getter steps are to return
-<a>this</a>'s <a for=/>notification</a>'s <a for=notification>vibration pattern</a>.
 
 <p>The <dfn attribute for=Notification><code>timestamp</code></dfn> getter steps are to return
 <a>this</a>'s <a for=/>notification</a>'s <a for=notification>timestamp</a>.

--- a/notifications.bs
+++ b/notifications.bs
@@ -81,8 +81,8 @@ initially false. When true, indicates that the end user should be alerted after 
 
 <p>A <a for=/>notification</a> has an associated
 <dfn for=notification id=silent-preference-flag>silent preference</dfn> (null or a boolean). It is
-initially null. When true, indicates that no sounds should be made. When null, indicates that
-producing sounds should be left to platform conventions.
+initially null. When true, indicates that no sounds or vibrations should be made. When null,
+indicates that producing sounds or vibrations should be left to platform conventions.
 
 <p>A <a for=/>notification</a> has an associated
 <dfn for=notification id=require-interaction-preference-flag>require interaction preference</dfn>

--- a/notifications.bs
+++ b/notifications.bs
@@ -8,6 +8,7 @@ Abstract: This standard defines an API to display notifications to the end user,
 Translation: ja https://triple-underscore.github.io/notifications-ja.html
 Translation: zh-Hans https://htmlspecs.com/notifications/
 Translation: ko https://ko.htmlspecs.com/notifications/
+Ignore MDN Failure: #dom-notification-vibrate
 </pre>
 
 <pre class=anchors>
@@ -640,9 +641,8 @@ the end user, the <a>close steps</a> for it must be run.
 
 <h3 id=alerting-the-user>Alerting the end user</h3>
 
-<p>The <dfn>alert steps</dfn> for alerting the end user about a given <a for=/>notification</a>
-<var>notification</var> are to optionally alert the end user in a user-agent-defined manner (e.g.,
-by playing a sound).
+<p>The <dfn>alert steps</dfn> for alerting the end user about a given <a for=/>notification</a> are
+to optionally alert the end user in a user-agent-defined manner (e.g., by playing a sound).
 
 
 <h2 id=api>API</h2>

--- a/notifications.bs
+++ b/notifications.bs
@@ -8,7 +8,6 @@ Abstract: This standard defines an API to display notifications to the end user,
 Translation: ja https://triple-underscore.github.io/notifications-ja.html
 Translation: zh-Hans https://htmlspecs.com/notifications/
 Translation: ko https://ko.htmlspecs.com/notifications/
-Ignore MDN Failure: #dom-notification-vibrate
 </pre>
 
 <pre class=anchors>


### PR DESCRIPTION
Remove vibration support from notifications

This PR removes vibration support from notifications.

The feature does not have interoperable browser implementations.

Current implementation status appears to be:

* Chromium-based browsers: implemented for Android, but [support removed in Android 8](https://github.com/whatwg/notifications/pull/241#issuecomment-4409342501)
* Firefox: not implemented (https://bugzilla.mozilla.org/show_bug.cgi?id=1273641)
* WebKit: not implemented

As a result, the feature is effectively a single-engine extension.

The generic Vibration API (`Navigator.vibrate`) remains available for user agents that support vibration.

If there is implementer interest in maintaining this feature, that information would be helpful in determining whether it should remain in the specification.

<!--
Thank you for contributing to the Notifications API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * WebKit: feature not implemented
   * Gecko
   * Chromium (per https://github.com/whatwg/notifications/pull/241#issuecomment-4409342501)
- [X] Tests are written and can be reviewed and commented upon at:
   * Historical: https://github.com/web-platform-tests/wpt/pull/58470
   * None existing — no notification-specific WPT coverage appears to exist for this feature beyond any Web IDL harness coverage
- [x] Implementation bugs are filed:
   * Chromium: https://crbug.com/511304741
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1273641 (should be closed after)
   * WebKit: N/A (feature not implemented nor planned)
- [x] MDN issue is filed: https://github.com/mdn/mdn/issues/825
- [x] The top of this comment includes a clear commit message to use.

(See https://whatwg.org/working-mode#changes for more details.)(https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 9, 2026, 12:44 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmarcoscaceres%2Fnotifications%2Fe1bf6befcf176b6049a72dd12f0d76e27be6872d%2Fnotifications.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20241)

**Error output:**

```json
[
    {
        "lineNum": null,
        "messageType": "warning",
        "text": "Skipped generating some MDN panels, because the following IDs weren't present in the document. Use `Ignore MDN Failure` if this is expected.\n  #dom-notification-vibrate"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/notifications%23241.)._

</details>
